### PR TITLE
Update build status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Java CI](https://github.com/AY2526S2-CS2103T-T08-1/tp/actions/workflows/gradle.yml/badge.svg)](https://github.com/AY2526S2-CS2103T-T08-1/tp/actions/workflows/gradle.yml)
+[![CI Status](https://github.com/AY2526S2-CS2103T-T08-1/tp/actions/workflows/gradle.yml/badge.svg)](https://github.com/AY2526S2-CS2103T-T08-1/tp/actions/workflows/gradle.yml)
 
 ![Ui](docs/images/Ui.png)
 


### PR DESCRIPTION
Update the link of the GitHub Actions build status badge (Build Status) so that it reflects the build status of your team repo.
Closes #38 