### PR TITLE
Implement text wrapping for notes compartment 

### DIFF
--- a/src/main/resources/view/ContactListCard.fxml
+++ b/src/main/resources/view/ContactListCard.fxml
@@ -43,9 +43,9 @@
                <Insets bottom="5.0" left="15.0" right="5.0" top="5.0" />
             </padding>
          </VBox>
-         <VBox alignment="CENTER_LEFT">
+         <VBox alignment="CENTER_LEFT" maxHeight="62.4">
             <children>
-            <Label fx:id="notes" styleClass="cell_small_label" text="\$notes" />
+            <Label fx:id="notes" styleClass="cell_small_label" text="\$notes" wrapText="true" />
             </children>
             <padding>
                <Insets bottom="5.0" left="15.0" right="5.0" top="5.0" />


### PR DESCRIPTION
Reformat the UI such that the notes compartment never exceeds 3 rows in space, wraps text for a single line of long text and uses ellipses "..." to indicate additional hidden text if needed.

Resolves #82.