### PR TITLE
Feat: remove optional fields on empty edit prefix (#157)

### DIFF
--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -55,6 +55,8 @@ public class EditCommand extends Command {
     public static final String MESSAGE_EDIT_CONTACT_SUCCESS = "Edited Contact: %1$s";
     public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
     public static final String MESSAGE_DUPLICATE_CONTACT = "This contact already exists in the address book.";
+    public static final String MESSAGE_MUST_HAVE_CONTACT_METHOD =
+            "A contact must have at least a phone number or an email address.";
 
     private final Index index;
     private final EditContactDescriptor editContactDescriptor;
@@ -83,6 +85,10 @@ public class EditCommand extends Command {
         Contact contactToEdit = lastShownList.get(index.getZeroBased());
         Contact editedContact = createEditedContact(contactToEdit, editContactDescriptor);
 
+        if (editedContact.getPhone().isEmpty() && editedContact.getEmail().isEmpty()) {
+            throw new CommandException(MESSAGE_MUST_HAVE_CONTACT_METHOD);
+        }
+
         if (!contactToEdit.isSameContact(editedContact) && model.hasContact(editedContact)) {
             throw new CommandException(MESSAGE_DUPLICATE_CONTACT);
         }
@@ -103,11 +109,18 @@ public class EditCommand extends Command {
         assert contactToEdit != null;
 
         Name updatedName = editContactDescriptor.getName().orElse(contactToEdit.getName());
-        Optional<Phone> updatedPhone = editContactDescriptor.getPhone().or(() -> contactToEdit.getPhone());
-        Optional<Email> updatedEmail = editContactDescriptor.getEmail().or(() -> contactToEdit.getEmail());
-        Optional<Address> updatedAddress = editContactDescriptor.getAddress().or(() -> contactToEdit.getAddress());
-        Optional<LastContacted> updatedLastContacted =
-                editContactDescriptor.getLastContacted().or(() -> contactToEdit.getLastContacted());
+        Optional<Phone> updatedPhone = editContactDescriptor.isClearPhone()
+                ? Optional.empty()
+                : editContactDescriptor.getPhone().or(() -> contactToEdit.getPhone());
+        Optional<Email> updatedEmail = editContactDescriptor.isClearEmail()
+                ? Optional.empty()
+                : editContactDescriptor.getEmail().or(() -> contactToEdit.getEmail());
+        Optional<Address> updatedAddress = editContactDescriptor.isClearAddress()
+                ? Optional.empty()
+                : editContactDescriptor.getAddress().or(() -> contactToEdit.getAddress());
+        Optional<LastContacted> updatedLastContacted = editContactDescriptor.isClearLastContacted()
+                ? Optional.empty()
+                : editContactDescriptor.getLastContacted().or(() -> contactToEdit.getLastContacted());
         List<Note> updatedNotes = contactToEdit.getNotes();
         Set<Tag> updatedTags = editContactDescriptor.getTags().orElse(contactToEdit.getTags());
 
@@ -150,6 +163,10 @@ public class EditCommand extends Command {
         private Address address;
         private LastContacted lastContacted;
         private Set<Tag> tags;
+        private boolean clearPhone;
+        private boolean clearEmail;
+        private boolean clearAddress;
+        private boolean clearLastContacted;
 
         public EditContactDescriptor() {}
 
@@ -164,13 +181,18 @@ public class EditCommand extends Command {
             setAddress(toCopy.address);
             setLastContacted(toCopy.lastContacted);
             setTags(toCopy.tags);
+            this.clearPhone = toCopy.clearPhone;
+            this.clearEmail = toCopy.clearEmail;
+            this.clearAddress = toCopy.clearAddress;
+            this.clearLastContacted = toCopy.clearLastContacted;
         }
 
         /**
          * Returns true if at least one field is edited.
          */
         public boolean isAnyFieldEdited() {
-            return CollectionUtil.isAnyNonNull(name, phone, email, address, lastContacted, tags);
+            return CollectionUtil.isAnyNonNull(name, phone, email, address, lastContacted, tags)
+                    || clearPhone || clearEmail || clearAddress || clearLastContacted;
         }
 
         public void setName(Name name) {
@@ -213,6 +235,38 @@ public class EditCommand extends Command {
             return Optional.ofNullable(lastContacted);
         }
 
+        public void setClearPhone(boolean clearPhone) {
+            this.clearPhone = clearPhone;
+        }
+
+        public boolean isClearPhone() {
+            return clearPhone;
+        }
+
+        public void setClearEmail(boolean clearEmail) {
+            this.clearEmail = clearEmail;
+        }
+
+        public boolean isClearEmail() {
+            return clearEmail;
+        }
+
+        public void setClearAddress(boolean clearAddress) {
+            this.clearAddress = clearAddress;
+        }
+
+        public boolean isClearAddress() {
+            return clearAddress;
+        }
+
+        public void setClearLastContacted(boolean clearLastContacted) {
+            this.clearLastContacted = clearLastContacted;
+        }
+
+        public boolean isClearLastContacted() {
+            return clearLastContacted;
+        }
+
         /**
          * Sets {@code tags} to this object's {@code tags}.
          * A defensive copy of {@code tags} is used internally.
@@ -247,7 +301,11 @@ public class EditCommand extends Command {
                     && Objects.equals(email, otherEditContactDescriptor.email)
                     && Objects.equals(address, otherEditContactDescriptor.address)
                     && Objects.equals(lastContacted, otherEditContactDescriptor.lastContacted)
-                    && Objects.equals(tags, otherEditContactDescriptor.tags);
+                    && Objects.equals(tags, otherEditContactDescriptor.tags)
+                    && clearPhone == otherEditContactDescriptor.clearPhone
+                    && clearEmail == otherEditContactDescriptor.clearEmail
+                    && clearAddress == otherEditContactDescriptor.clearAddress
+                    && clearLastContacted == otherEditContactDescriptor.clearLastContacted;
         }
 
         @Override
@@ -259,6 +317,10 @@ public class EditCommand extends Command {
                     .add("address", address)
                     .add("lastContacted", lastContacted)
                     .add("tags", tags)
+                    .add("clearPhone", clearPhone)
+                    .add("clearEmail", clearEmail)
+                    .add("clearAddress", clearAddress)
+                    .add("clearLastContacted", clearLastContacted)
                     .toString();
         }
     }

--- a/src/main/java/seedu/address/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCommandParser.java
@@ -53,17 +53,36 @@ public class EditCommandParser implements Parser<EditCommand> {
             editContactDescriptor.setName(ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get()));
         }
         if (argMultimap.getValue(PREFIX_PHONE).isPresent()) {
-            editContactDescriptor.setPhone(ParserUtil.parsePhone(argMultimap.getValue(PREFIX_PHONE).get()));
+            String phoneValue = argMultimap.getValue(PREFIX_PHONE).get().trim();
+            if (phoneValue.isEmpty()) {
+                editContactDescriptor.setClearPhone(true);
+            } else {
+                editContactDescriptor.setPhone(ParserUtil.parsePhone(phoneValue));
+            }
         }
         if (argMultimap.getValue(PREFIX_EMAIL).isPresent()) {
-            editContactDescriptor.setEmail(ParserUtil.parseEmail(argMultimap.getValue(PREFIX_EMAIL).get()));
+            String emailValue = argMultimap.getValue(PREFIX_EMAIL).get().trim();
+            if (emailValue.isEmpty()) {
+                editContactDescriptor.setClearEmail(true);
+            } else {
+                editContactDescriptor.setEmail(ParserUtil.parseEmail(emailValue));
+            }
         }
         if (argMultimap.getValue(PREFIX_ADDRESS).isPresent()) {
-            editContactDescriptor.setAddress(ParserUtil.parseAddress(argMultimap.getValue(PREFIX_ADDRESS).get()));
+            String addressValue = argMultimap.getValue(PREFIX_ADDRESS).get().trim();
+            if (addressValue.isEmpty()) {
+                editContactDescriptor.setClearAddress(true);
+            } else {
+                editContactDescriptor.setAddress(ParserUtil.parseAddress(addressValue));
+            }
         }
         if (argMultimap.getValue(PREFIX_LAST_CONTACTED).isPresent()) {
-            editContactDescriptor.setLastContacted(
-                    ParserUtil.parseLastContacted(argMultimap.getValue(PREFIX_LAST_CONTACTED).get()));
+            String lastContactedValue = argMultimap.getValue(PREFIX_LAST_CONTACTED).get().trim();
+            if (lastContactedValue.isEmpty()) {
+                editContactDescriptor.setClearLastContacted(true);
+            } else {
+                editContactDescriptor.setLastContacted(ParserUtil.parseLastContacted(lastContactedValue));
+            }
         }
         parseTagsForEdit(argMultimap.getAllValues(PREFIX_TAG)).ifPresent(editContactDescriptor::setTags);
 

--- a/src/test/java/seedu/address/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditCommandTest.java
@@ -114,6 +114,34 @@ public class EditCommandTest {
     }
 
     @Test
+    public void execute_clearBothPhoneAndEmail_failure() {
+        EditContactDescriptor descriptor = new EditContactDescriptorBuilder()
+                .withClearPhone().withClearEmail().build();
+        EditCommand editCommand = new EditCommand(INDEX_FIRST_CONTACT, descriptor);
+
+        assertCommandFailure(editCommand, model, EditCommand.MESSAGE_MUST_HAVE_CONTACT_METHOD);
+    }
+
+    @Test
+    public void execute_clearPhoneKeepEmail_success() {
+        Contact firstContact = model.getDisplayedContactList().get(INDEX_FIRST_CONTACT.getZeroBased());
+        // First contact (ALICE) has both phone and email, so clearing phone should succeed
+        EditContactDescriptor descriptor = new EditContactDescriptorBuilder().withClearPhone().build();
+        EditCommand editCommand = new EditCommand(INDEX_FIRST_CONTACT, descriptor);
+
+        ContactBuilder contactInList = new ContactBuilder(firstContact);
+        Contact editedContact = contactInList.withoutPhone().build();
+
+        String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_CONTACT_SUCCESS,
+                Messages.format(editedContact));
+
+        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+        expectedModel.setContact(firstContact, editedContact);
+
+        assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
     public void execute_duplicateContactFilteredList_failure() {
         showContactAtIndex(model, INDEX_FIRST_CONTACT);
 

--- a/src/test/java/seedu/address/logic/commands/EditContactDescriptorTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditContactDescriptorTest.java
@@ -66,7 +66,11 @@ public class EditContactDescriptorTest {
                 + editContactDescriptor.getEmail().orElse(null) + ", address="
                 + editContactDescriptor.getAddress().orElse(null) + ", lastContacted="
                 + editContactDescriptor.getLastContacted().orElse(null) + ", tags="
-                + editContactDescriptor.getTags().orElse(null) + "}";
+                + editContactDescriptor.getTags().orElse(null) + ", clearPhone="
+                + editContactDescriptor.isClearPhone() + ", clearEmail="
+                + editContactDescriptor.isClearEmail() + ", clearAddress="
+                + editContactDescriptor.isClearAddress() + ", clearLastContacted="
+                + editContactDescriptor.isClearLastContacted() + "}";
         assertEquals(expected, editContactDescriptor.toString());
     }
 }

--- a/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
@@ -7,7 +7,6 @@ import static seedu.address.logic.commands.CommandTestUtil.EMAIL_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.EMAIL_DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_ADDRESS_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_EMAIL_DESC;
-import static seedu.address.logic.commands.CommandTestUtil.INVALID_LAST_CONTACTED_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_NAME_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_PHONE_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_TAG_DESC;
@@ -42,9 +41,7 @@ import seedu.address.commons.core.index.Index;
 import seedu.address.logic.Messages;
 import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.EditCommand.EditContactDescriptor;
-import seedu.address.model.contact.Address;
 import seedu.address.model.contact.Email;
-import seedu.address.model.contact.LastContacted;
 import seedu.address.model.contact.Name;
 import seedu.address.model.contact.Phone;
 import seedu.address.model.tag.Tag;
@@ -91,8 +88,6 @@ public class EditCommandParserTest {
         assertParseFailure(parser, "1" + INVALID_NAME_DESC, Name.MESSAGE_CONSTRAINTS); // invalid name
         assertParseFailure(parser, "1" + INVALID_PHONE_DESC, Phone.MESSAGE_CONSTRAINTS); // invalid phone
         assertParseFailure(parser, "1" + INVALID_EMAIL_DESC, Email.MESSAGE_CONSTRAINTS); // invalid email
-        assertParseFailure(parser, "1" + INVALID_ADDRESS_DESC, Address.MESSAGE_CONSTRAINTS); // invalid address
-        assertParseFailure(parser, "1" + INVALID_LAST_CONTACTED_DESC, LastContacted.MESSAGE_CONSTRAINTS);
         assertParseFailure(parser, "1" + INVALID_TAG_DESC, Tag.MESSAGE_CONSTRAINTS); // invalid tag
 
         // invalid phone followed by valid email
@@ -217,6 +212,50 @@ public class EditCommandParserTest {
         String userInput = targetIndex.getOneBased() + TAG_EMPTY;
 
         EditContactDescriptor descriptor = new EditContactDescriptorBuilder().withTags().build();
+        EditCommand expectedCommand = new EditCommand(targetIndex, descriptor);
+
+        assertParseSuccess(parser, userInput, expectedCommand);
+    }
+
+    @Test
+    public void parse_clearPhone_success() {
+        Index targetIndex = INDEX_FIRST_CONTACT;
+        String userInput = targetIndex.getOneBased() + " " + PREFIX_PHONE;
+
+        EditContactDescriptor descriptor = new EditContactDescriptorBuilder().withClearPhone().build();
+        EditCommand expectedCommand = new EditCommand(targetIndex, descriptor);
+
+        assertParseSuccess(parser, userInput, expectedCommand);
+    }
+
+    @Test
+    public void parse_clearEmail_success() {
+        Index targetIndex = INDEX_FIRST_CONTACT;
+        String userInput = targetIndex.getOneBased() + " " + PREFIX_EMAIL;
+
+        EditContactDescriptor descriptor = new EditContactDescriptorBuilder().withClearEmail().build();
+        EditCommand expectedCommand = new EditCommand(targetIndex, descriptor);
+
+        assertParseSuccess(parser, userInput, expectedCommand);
+    }
+
+    @Test
+    public void parse_clearAddress_success() {
+        Index targetIndex = INDEX_FIRST_CONTACT;
+        String userInput = targetIndex.getOneBased() + " " + PREFIX_ADDRESS;
+
+        EditContactDescriptor descriptor = new EditContactDescriptorBuilder().withClearAddress().build();
+        EditCommand expectedCommand = new EditCommand(targetIndex, descriptor);
+
+        assertParseSuccess(parser, userInput, expectedCommand);
+    }
+
+    @Test
+    public void parse_clearLastContacted_success() {
+        Index targetIndex = INDEX_FIRST_CONTACT;
+        String userInput = targetIndex.getOneBased() + " " + PREFIX_LAST_CONTACTED;
+
+        EditContactDescriptor descriptor = new EditContactDescriptorBuilder().withClearLastContacted().build();
         EditCommand expectedCommand = new EditCommand(targetIndex, descriptor);
 
         assertParseSuccess(parser, userInput, expectedCommand);

--- a/src/test/java/seedu/address/testutil/ContactBuilder.java
+++ b/src/test/java/seedu/address/testutil/ContactBuilder.java
@@ -109,10 +109,26 @@ public class ContactBuilder {
     }
 
     /**
+     * Clears the {@code Phone} of the {@code Contact} that we are building.
+     */
+    public ContactBuilder withoutPhone() {
+        this.phone = Optional.empty();
+        return this;
+    }
+
+    /**
      * Sets the {@code Email} of the {@code Contact} that we are building.
      */
     public ContactBuilder withEmail(String email) {
         this.email = email != null ? Optional.of(new Email(email)) : Optional.empty();
+        return this;
+    }
+
+    /**
+     * Clears the {@code Email} of the {@code Contact} that we are building.
+     */
+    public ContactBuilder withoutEmail() {
+        this.email = Optional.empty();
         return this;
     }
 

--- a/src/test/java/seedu/address/testutil/EditContactDescriptorBuilder.java
+++ b/src/test/java/seedu/address/testutil/EditContactDescriptorBuilder.java
@@ -91,6 +91,38 @@ public class EditContactDescriptorBuilder {
         return this;
     }
 
+    /**
+     * Sets the clear phone flag of the {@code EditContactDescriptor} that we are building.
+     */
+    public EditContactDescriptorBuilder withClearPhone() {
+        descriptor.setClearPhone(true);
+        return this;
+    }
+
+    /**
+     * Sets the clear email flag of the {@code EditContactDescriptor} that we are building.
+     */
+    public EditContactDescriptorBuilder withClearEmail() {
+        descriptor.setClearEmail(true);
+        return this;
+    }
+
+    /**
+     * Sets the clear address flag of the {@code EditContactDescriptor} that we are building.
+     */
+    public EditContactDescriptorBuilder withClearAddress() {
+        descriptor.setClearAddress(true);
+        return this;
+    }
+
+    /**
+     * Sets the clear last contacted flag of the {@code EditContactDescriptor} that we are building.
+     */
+    public EditContactDescriptorBuilder withClearLastContacted() {
+        descriptor.setClearLastContacted(true);
+        return this;
+    }
+
     public EditContactDescriptor build() {
         return descriptor;
     }


### PR DESCRIPTION
When a user inputs a field prefix with no argument (e.g. edit 1 p/), the field is removed from the contact. Supported for phone, email, address, and lastContacted fields.

Validation ensures the resultant contact still has at least a phone number or email address.

closes #157 