### PR TITLE
Add help for specific commands

### DIFF
--- a/src/main/java/seedu/address/logic/commands/CommandResult.java
+++ b/src/main/java/seedu/address/logic/commands/CommandResult.java
@@ -15,8 +15,8 @@ public class CommandResult {
 
     private final String feedbackToUser;
 
-    /** Help information should be shown to the user. */
-    private final boolean showHelp;
+    /** Help information to be shown to the user, or null if no help window needed. */
+    private final HelpInfo helpInfo;
 
     /** The application should exit. */
     private final boolean exit;
@@ -36,7 +36,7 @@ public class CommandResult {
     public CommandResult(String feedbackToUser, boolean showHelp, boolean exit,
             Contact contactToView, boolean hideViewPanel, boolean showFileList) {
         this.feedbackToUser = requireNonNull(feedbackToUser);
-        this.showHelp = showHelp;
+        this.helpInfo = showHelp ? HelpInfo.DEFAULT : null;
         this.exit = exit;
         this.contactToView = contactToView;
         this.hideViewPanel = hideViewPanel;
@@ -51,12 +51,32 @@ public class CommandResult {
         this(feedbackToUser, false, false, null, false, false);
     }
 
+    /**
+     * Constructs a {@code CommandResult} with the given {@code HelpInfo}.
+     * The help window will be shown with the given help info.
+     */
+    public CommandResult(String feedbackToUser, HelpInfo helpInfo) {
+        this.feedbackToUser = requireNonNull(feedbackToUser);
+        this.helpInfo = requireNonNull(helpInfo);
+        this.exit = false;
+        this.contactToView = null;
+        this.hideViewPanel = false;
+        this.showFileList = false;
+    }
+
     public String getFeedbackToUser() {
         return feedbackToUser;
     }
 
     public boolean isShowHelp() {
-        return showHelp;
+        return helpInfo != null;
+    }
+
+    /**
+     * Returns the help info, if any.
+     */
+    public Optional<HelpInfo> getHelpInfo() {
+        return Optional.ofNullable(helpInfo);
     }
 
     public boolean isExit() {
@@ -104,7 +124,7 @@ public class CommandResult {
 
         CommandResult otherCommandResult = (CommandResult) other;
         return feedbackToUser.equals(otherCommandResult.feedbackToUser)
-                && showHelp == otherCommandResult.showHelp
+                && Objects.equals(helpInfo, otherCommandResult.helpInfo)
                 && exit == otherCommandResult.exit
                 && Objects.equals(contactToView, otherCommandResult.contactToView)
                 && hideViewPanel == otherCommandResult.hideViewPanel;
@@ -112,14 +132,14 @@ public class CommandResult {
 
     @Override
     public int hashCode() {
-        return Objects.hash(feedbackToUser, showHelp, exit, contactToView, hideViewPanel);
+        return Objects.hash(feedbackToUser, helpInfo, exit, contactToView, hideViewPanel);
     }
 
     @Override
     public String toString() {
         return new ToStringBuilder(this)
                 .add("feedbackToUser", feedbackToUser)
-                .add("showHelp", showHelp)
+                .add("helpInfo", helpInfo)
                 .add("exit", exit)
                 .add("contactToView", contactToView)
                 .add("hideViewPanel", hideViewPanel)
@@ -129,12 +149,11 @@ public class CommandResult {
 
 class HelpCommandResult extends CommandResult {
     /**
-     * Constructs a {@code CommandResult} with the specified {@code feedbackToUser},
-     * {@code showHelp} set to {@code true},
-     * and other fields set to their default value.
+     * Constructs a {@code CommandResult} with the specified {@code HelpInfo},
+     * which will trigger the help window to open with the given info.
      */
-    public HelpCommandResult(String feedbackToUser) {
-        super(feedbackToUser, true, false, null, false, false);
+    public HelpCommandResult(String feedbackToUser, HelpInfo helpInfo) {
+        super(feedbackToUser, helpInfo);
     }
 }
 

--- a/src/main/java/seedu/address/logic/commands/HelpCommand.java
+++ b/src/main/java/seedu/address/logic/commands/HelpCommand.java
@@ -1,21 +1,133 @@
 package seedu.address.logic.commands;
 
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
+
 import seedu.address.model.Model;
 
 /**
  * Format full help instructions for every command for display.
+ * Opens the help window with command-specific information and a link to the User Guide.
  */
 public class HelpCommand extends Command {
 
     public static final String COMMAND_WORD = "help";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Shows program usage instructions.\n"
-            + "Example: " + COMMAND_WORD;
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Shows program usage instructions.\n"
+            + "To show help for a specific command: " + COMMAND_WORD + " COMMAND\n"
+            + "Example: " + COMMAND_WORD + "\n"
+            + "Example: " + COMMAND_WORD + " add";
 
     public static final String SHOWING_HELP_MESSAGE = "Opened help window.";
 
+    public static final String MESSAGE_UNKNOWN_COMMAND = "Unknown command: %s\n"
+            + "Available commands: %s";
+
+    private static final String UG_COMMANDS_URL = HelpInfo.USER_GUIDE_BASE_URL + "commands/";
+
+    private static final Map<String, HelpInfo> COMMAND_HELP_MAP = new LinkedHashMap<>();
+
+    static {
+        COMMAND_HELP_MAP.put(AddCommand.COMMAND_WORD,
+                new HelpInfo(AddCommand.MESSAGE_USAGE, UG_COMMANDS_URL + "add-contact.html"));
+        COMMAND_HELP_MAP.put(ClearCommand.COMMAND_WORD,
+                new HelpInfo("clear: Clears the address book.\nExample: clear",
+                        UG_COMMANDS_URL + "clear-contacts.html"));
+        COMMAND_HELP_MAP.put(CloseViewCommand.COMMAND_WORD,
+                new HelpInfo(CloseViewCommand.MESSAGE_USAGE,
+                        UG_COMMANDS_URL + "close-view-contact.html"));
+        COMMAND_HELP_MAP.put(DeleteCommand.COMMAND_WORD,
+                new HelpInfo(DeleteCommand.MESSAGE_USAGE,
+                        UG_COMMANDS_URL + "delete-contact.html"));
+        COMMAND_HELP_MAP.put(EditCommand.COMMAND_WORD,
+                new HelpInfo(EditCommand.MESSAGE_USAGE,
+                        UG_COMMANDS_URL + "edit-contact.html"));
+        COMMAND_HELP_MAP.put(ExitCommand.COMMAND_WORD,
+                new HelpInfo("exit: Terminates the program.\nExample: exit",
+                        UG_COMMANDS_URL + "exit-program.html"));
+        COMMAND_HELP_MAP.put(FileCommand.COMMAND_WORD,
+                new HelpInfo(FileCommand.MESSAGE_USAGE,
+                        UG_COMMANDS_URL + "file.html"));
+        COMMAND_HELP_MAP.put(FindCommand.COMMAND_WORD,
+                new HelpInfo(FindCommand.MESSAGE_USAGE,
+                        UG_COMMANDS_URL + "find-contacts.html"));
+        COMMAND_HELP_MAP.put(COMMAND_WORD,
+                new HelpInfo(MESSAGE_USAGE,
+                        UG_COMMANDS_URL + "view-help.html"));
+        COMMAND_HELP_MAP.put(ListCommand.COMMAND_WORD,
+                new HelpInfo("list: Lists all contacts in the address book.\nExample: list",
+                        UG_COMMANDS_URL + "list-contacts.html"));
+        COMMAND_HELP_MAP.put(NoteCommand.COMMAND_WORD,
+                new HelpInfo(NoteCommand.MESSAGE_USAGE,
+                        UG_COMMANDS_URL + "notes.html"));
+        COMMAND_HELP_MAP.put(RedoCommand.COMMAND_WORD,
+                new HelpInfo(RedoCommand.MESSAGE_USAGE,
+                        UG_COMMANDS_URL + "redo-command.html"));
+        COMMAND_HELP_MAP.put(SortCommand.COMMAND_WORD,
+                new HelpInfo(SortCommand.MESSAGE_USAGE,
+                        UG_COMMANDS_URL + "sort-contacts.html"));
+        COMMAND_HELP_MAP.put(ThemeCommand.COMMAND_WORD,
+                new HelpInfo(ThemeCommand.MESSAGE_USAGE,
+                        UG_COMMANDS_URL + "set-theme.html"));
+        COMMAND_HELP_MAP.put(UndoCommand.COMMAND_WORD,
+                new HelpInfo(UndoCommand.MESSAGE_USAGE,
+                        UG_COMMANDS_URL + "undo-command.html"));
+        COMMAND_HELP_MAP.put(ViewCommand.COMMAND_WORD,
+                new HelpInfo(ViewCommand.MESSAGE_USAGE,
+                        UG_COMMANDS_URL + "view-contact.html"));
+    }
+
+    private final String commandWord;
+
+    /**
+     * Creates a HelpCommand that opens the general help window.
+     */
+    public HelpCommand() {
+        this.commandWord = null;
+    }
+
+    /**
+     * Creates a HelpCommand that shows help for a specific command.
+     */
+    public HelpCommand(String commandWord) {
+        this.commandWord = commandWord;
+    }
+
+    /**
+     * Returns the available command words as a comma-separated string.
+     */
+    public static String getAvailableCommands() {
+        return COMMAND_HELP_MAP.keySet().stream().collect(Collectors.joining(", "));
+    }
+
     @Override
     public CommandResult execute(Model model) {
-        return new HelpCommandResult(SHOWING_HELP_MESSAGE);
+        if (commandWord == null) {
+            return new HelpCommandResult(SHOWING_HELP_MESSAGE, HelpInfo.DEFAULT);
+        }
+
+        HelpInfo helpInfo = COMMAND_HELP_MAP.get(commandWord);
+        if (helpInfo == null) {
+            return new CommandResult(String.format(MESSAGE_UNKNOWN_COMMAND,
+                    commandWord, getAvailableCommands()));
+        }
+        return new HelpCommandResult(SHOWING_HELP_MESSAGE, helpInfo);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if (!(other instanceof HelpCommand)) {
+            return false;
+        }
+        HelpCommand otherCommand = (HelpCommand) other;
+        if (commandWord == null) {
+            return otherCommand.commandWord == null;
+        }
+        return commandWord.equals(otherCommand.commandWord);
     }
 }

--- a/src/main/java/seedu/address/logic/commands/HelpInfo.java
+++ b/src/main/java/seedu/address/logic/commands/HelpInfo.java
@@ -1,0 +1,63 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.Objects;
+
+/**
+ * Represents help information to be displayed in the help window.
+ * Contains a message describing the command and a URL to the relevant User Guide page.
+ */
+public class HelpInfo {
+
+    public static final String USER_GUIDE_BASE_URL =
+            "https://ay2526s2-cs2103t-t08-1.github.io/tp/user-guide/";
+
+    /** Default help info pointing to the main User Guide page. */
+    public static final HelpInfo DEFAULT = new HelpInfo(
+            "Refer to the user guide for more information.",
+            USER_GUIDE_BASE_URL + "index.html");
+
+    private final String message;
+    private final String url;
+
+    /**
+     * Constructs a {@code HelpInfo} with the given message and URL.
+     */
+    public HelpInfo(String message, String url) {
+        requireNonNull(message);
+        requireNonNull(url);
+        this.message = message;
+        this.url = url;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public String getUrl() {
+        return url;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if (!(other instanceof HelpInfo)) {
+            return false;
+        }
+        HelpInfo otherInfo = (HelpInfo) other;
+        return message.equals(otherInfo.message) && url.equals(otherInfo.url);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(message, url);
+    }
+
+    @Override
+    public String toString() {
+        return "HelpInfo{message=" + message + ", url=" + url + "}";
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -87,7 +87,11 @@ public class AddressBookParser {
             return new FindCommandParser().parse(arguments);
 
         case HelpCommand.COMMAND_WORD:
-            return new HelpCommand();
+            String helpArgs = arguments.trim();
+            if (helpArgs.isEmpty()) {
+                return new HelpCommand();
+            }
+            return new HelpCommand(helpArgs);
 
         case ListCommand.COMMAND_WORD:
             return new ListCommand();

--- a/src/main/java/seedu/address/ui/HelpWindow.java
+++ b/src/main/java/seedu/address/ui/HelpWindow.java
@@ -10,13 +10,14 @@ import javafx.scene.input.Clipboard;
 import javafx.scene.input.ClipboardContent;
 import javafx.stage.Stage;
 import seedu.address.commons.core.LogsCenter;
+import seedu.address.logic.commands.HelpInfo;
 
 /**
  * Controller for a help page
  */
 public class HelpWindow extends UiPart<Stage> {
 
-    public static final String USER_GUIDE_URL = "https://ay2526s2-cs2103t-t08-1.github.io/tp/user-guide/index.html";
+    public static final String USER_GUIDE_URL = HelpInfo.USER_GUIDE_BASE_URL + "index.html";
     public static final String HELP_MESSAGE = "Refer to the user guide: " + USER_GUIDE_URL;
 
     private static final Logger logger = LogsCenter.getLogger(HelpWindow.class);
@@ -24,6 +25,7 @@ public class HelpWindow extends UiPart<Stage> {
 
     private Stage stage;
     private String[] stylesheets;
+    private String currentUrl = USER_GUIDE_URL;
 
     @FXML
     private Button copyButton;
@@ -52,6 +54,14 @@ public class HelpWindow extends UiPart<Stage> {
      */
     public HelpWindow() {
         this(new Stage());
+    }
+
+    /**
+     * Updates the help window content with the given {@code HelpInfo}.
+     */
+    public void setHelpInfo(HelpInfo helpInfo) {
+        currentUrl = helpInfo.getUrl();
+        helpMessage.setText(helpInfo.getMessage() + "\n\nUser Guide: " + currentUrl);
     }
 
     /**
@@ -100,13 +110,13 @@ public class HelpWindow extends UiPart<Stage> {
     }
 
     /**
-     * Copies the URL to the user guide to the clipboard.
+     * Copies the current URL to the clipboard.
      */
     @FXML
     private void copyUrl() {
         final Clipboard clipboard = Clipboard.getSystemClipboard();
         final ClipboardContent url = new ClipboardContent();
-        url.putString(USER_GUIDE_URL);
+        url.putString(currentUrl);
         clipboard.setContent(url);
     }
 

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -285,6 +285,66 @@ public class MainWindow extends UiPart<Stage> {
         executeCommand("help");
     }
 
+    @FXML
+    private void handleHelpAdd() throws CommandException, ParseException {
+        executeCommand("help add");
+    }
+
+    @FXML
+    private void handleHelpClear() throws CommandException, ParseException {
+        executeCommand("help clear");
+    }
+
+    @FXML
+    private void handleHelpClose() throws CommandException, ParseException {
+        executeCommand("help close");
+    }
+
+    @FXML
+    private void handleHelpDelete() throws CommandException, ParseException {
+        executeCommand("help delete");
+    }
+
+    @FXML
+    private void handleHelpEdit() throws CommandException, ParseException {
+        executeCommand("help edit");
+    }
+
+    @FXML
+    private void handleHelpFile() throws CommandException, ParseException {
+        executeCommand("help file");
+    }
+
+    @FXML
+    private void handleHelpFind() throws CommandException, ParseException {
+        executeCommand("help find");
+    }
+
+    @FXML
+    private void handleHelpList() throws CommandException, ParseException {
+        executeCommand("help list");
+    }
+
+    @FXML
+    private void handleHelpNote() throws CommandException, ParseException {
+        executeCommand("help note");
+    }
+
+    @FXML
+    private void handleHelpSort() throws CommandException, ParseException {
+        executeCommand("help sort");
+    }
+
+    @FXML
+    private void handleHelpTheme() throws CommandException, ParseException {
+        executeCommand("help theme");
+    }
+
+    @FXML
+    private void handleHelpView() throws CommandException, ParseException {
+        executeCommand("help view");
+    }
+
     /**
      * Opens the help window or focuses on it if it's already opened.
      */
@@ -415,6 +475,7 @@ public class MainWindow extends UiPart<Stage> {
             resultDisplay.setFeedbackToUser(commandResult.getFeedbackToUser());
 
             if (commandResult.isShowHelp()) {
+                commandResult.getHelpInfo().ifPresent(helpWindow::setHelpInfo);
                 showHelpWindow();
             }
 

--- a/src/main/resources/view/HelpWindow.fxml
+++ b/src/main/resources/view/HelpWindow.fxml
@@ -6,10 +6,10 @@
 <?import javafx.scene.control.Button?>
 <?import javafx.scene.control.Label?>
 <?import javafx.scene.image.Image?>
-<?import javafx.scene.layout.HBox?>
+<?import javafx.scene.layout.VBox?>
 <?import javafx.stage.Stage?>
 
-<fx:root resizable="false" title="Help" type="javafx.stage.Stage" xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1">
+<fx:root resizable="true" title="Help" type="javafx.stage.Stage" minWidth="600" minHeight="200" xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1">
   <icons>
     <Image url="@/images/help_icon.png" />
   </icons>
@@ -19,26 +19,23 @@
         <URL value="@HelpWindow.css" />
       </stylesheets>
 
-      <HBox alignment="CENTER" fx:id="helpMessageContainer">
+      <VBox alignment="CENTER" fx:id="helpMessageContainer">
         <children>
-          <Label fx:id="helpMessage" text="Label">
-            <HBox.margin>
-              <Insets right="5.0" />
-            </HBox.margin>
+          <Label fx:id="helpMessage" text="Label" wrapText="true" maxWidth="580">
+            <VBox.margin>
+              <Insets bottom="10.0" left="10.0" right="10.0" top="10.0" />
+            </VBox.margin>
           </Label>
           <Button fx:id="copyButton" mnemonicParsing="false" onAction="#copyUrl" text="Copy URL">
-            <HBox.margin>
-              <Insets left="5.0" />
-            </HBox.margin>
+            <VBox.margin>
+              <Insets bottom="10.0" />
+            </VBox.margin>
           </Button>
         </children>
-        <opaqueInsets>
-          <Insets bottom="10.0" left="5.0" right="10.0" top="5.0" />
-        </opaqueInsets>
         <padding>
           <Insets bottom="10.0" left="5.0" right="10.0" top="5.0" />
         </padding>
-      </HBox>
+      </VBox>
     </Scene>
   </scene>
 </fx:root>

--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -30,7 +30,19 @@
             <MenuItem mnemonicParsing="false" onAction="#handleExit" text="Exit" />
           </Menu>
           <Menu mnemonicParsing="false" text="Help">
-            <MenuItem fx:id="helpMenuItem" mnemonicParsing="false" onAction="#handleHelp" text="Help" />
+            <MenuItem fx:id="helpMenuItem" mnemonicParsing="false" onAction="#handleHelp" text="User Guide" />
+            <MenuItem mnemonicParsing="false" onAction="#handleHelpAdd" text="add" />
+            <MenuItem mnemonicParsing="false" onAction="#handleHelpClear" text="clear" />
+            <MenuItem mnemonicParsing="false" onAction="#handleHelpClose" text="close" />
+            <MenuItem mnemonicParsing="false" onAction="#handleHelpDelete" text="delete" />
+            <MenuItem mnemonicParsing="false" onAction="#handleHelpEdit" text="edit" />
+            <MenuItem mnemonicParsing="false" onAction="#handleHelpFile" text="file" />
+            <MenuItem mnemonicParsing="false" onAction="#handleHelpFind" text="find" />
+            <MenuItem mnemonicParsing="false" onAction="#handleHelpList" text="list" />
+            <MenuItem mnemonicParsing="false" onAction="#handleHelpNote" text="note" />
+            <MenuItem mnemonicParsing="false" onAction="#handleHelpSort" text="sort" />
+            <MenuItem mnemonicParsing="false" onAction="#handleHelpTheme" text="theme" />
+            <MenuItem mnemonicParsing="false" onAction="#handleHelpView" text="view" />
           </Menu>
           <Menu mnemonicParsing="false" text="View">
             <MenuItem mnemonicParsing="false" onAction="#handleViewFiles" text="Files" />

--- a/src/test/java/seedu/address/logic/commands/CommandResultTest.java
+++ b/src/test/java/seedu/address/logic/commands/CommandResultTest.java
@@ -61,7 +61,7 @@ public class CommandResultTest {
     public void toStringMethod() {
         CommandResult commandResult = new CommandResult("feedback");
         String expected = CommandResult.class.getCanonicalName() + "{feedbackToUser="
-                + commandResult.getFeedbackToUser() + ", showHelp=" + commandResult.isShowHelp()
+                + commandResult.getFeedbackToUser() + ", helpInfo=" + commandResult.getHelpInfo().orElse(null)
                 + ", exit=" + commandResult.isExit() + ", contactToView=null"
                 + ", hideViewPanel=false}";
         assertEquals(expected, commandResult.toString());
@@ -164,5 +164,36 @@ public class CommandResultTest {
         // different hideContactDetail -> returns different hashcode
         assertNotEquals(commandResult.hashCode(),
                 new CommandResult("feedback", false, false, null, false, false).hashCode());
+    }
+
+    @Test
+    public void constructor_withHelpInfo_setsFieldsCorrectly() {
+        HelpInfo helpInfo = new HelpInfo("msg", "https://example.com");
+        CommandResult result = new CommandResult("feedback", helpInfo);
+
+        assertEquals("feedback", result.getFeedbackToUser());
+        assertTrue(result.isShowHelp());
+        assertTrue(result.getHelpInfo().isPresent());
+        assertEquals(helpInfo, result.getHelpInfo().get());
+        assertFalse(result.isExit());
+        assertFalse(result.isShowContactDetail());
+        assertFalse(result.isHideViewPanel());
+        assertFalse(result.isShowFileList());
+    }
+
+    @Test
+    public void equals_withHelpInfo() {
+        HelpInfo helpInfo = new HelpInfo("msg", "https://example.com");
+        HelpInfo otherInfo = new HelpInfo("other", "https://other.com");
+        CommandResult result = new CommandResult("feedback", helpInfo);
+
+        // same values -> true
+        assertTrue(result.equals(new CommandResult("feedback", helpInfo)));
+
+        // different helpInfo -> false
+        assertFalse(result.equals(new CommandResult("feedback", otherInfo)));
+
+        // no helpInfo vs helpInfo -> false
+        assertFalse(result.equals(new CommandResult("feedback")));
     }
 }

--- a/src/test/java/seedu/address/logic/commands/HelpCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/HelpCommandTest.java
@@ -1,6 +1,8 @@
 package seedu.address.logic.commands;
 
-import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.commands.HelpCommand.SHOWING_HELP_MESSAGE;
 
 import org.junit.jupiter.api.Test;
@@ -13,8 +15,94 @@ public class HelpCommandTest {
     private Model expectedModel = new ModelManager();
 
     @Test
-    public void execute_help_success() {
-        CommandResult expectedCommandResult = new CommandResult(SHOWING_HELP_MESSAGE, true, false, null, false, false);
-        assertCommandSuccess(new HelpCommand(), model, expectedCommandResult, expectedModel);
+    public void execute_noArgs_showsHelpWindow() {
+        HelpCommand helpCommand = new HelpCommand();
+        CommandResult result = helpCommand.execute(model);
+        assertTrue(result.isShowHelp());
+        assertEquals(SHOWING_HELP_MESSAGE, result.getFeedbackToUser());
+        assertTrue(result.getHelpInfo().isPresent());
+        assertEquals(HelpInfo.DEFAULT, result.getHelpInfo().get());
+    }
+
+    @Test
+    public void execute_validCommand_showsHelpWindowWithCommandInfo() {
+        HelpCommand helpAdd = new HelpCommand("add");
+        CommandResult result = helpAdd.execute(model);
+        assertTrue(result.isShowHelp());
+        assertTrue(result.getHelpInfo().isPresent());
+        assertEquals(AddCommand.MESSAGE_USAGE, result.getHelpInfo().get().getMessage());
+        assertTrue(result.getHelpInfo().get().getUrl().contains("add-contact.html"));
+    }
+
+    @Test
+    public void execute_helpForHelp_showsHelpWindowWithHelpInfo() {
+        HelpCommand helpHelp = new HelpCommand("help");
+        CommandResult result = helpHelp.execute(model);
+        assertTrue(result.isShowHelp());
+        assertTrue(result.getHelpInfo().isPresent());
+        assertEquals(HelpCommand.MESSAGE_USAGE, result.getHelpInfo().get().getMessage());
+        assertTrue(result.getHelpInfo().get().getUrl().contains("view-help.html"));
+    }
+
+    @Test
+    public void execute_unknownCommand_showsError() {
+        HelpCommand helpUnknown = new HelpCommand("foobar");
+        CommandResult result = helpUnknown.execute(model);
+        assertFalse(result.isShowHelp());
+        assertTrue(result.getFeedbackToUser().contains("Unknown command: foobar"));
+        assertTrue(result.getFeedbackToUser().contains("Available commands:"));
+    }
+
+    @Test
+    public void execute_fileCommand_showsHelpWindow() {
+        HelpCommand helpFile = new HelpCommand("file");
+        CommandResult result = helpFile.execute(model);
+        assertTrue(result.isShowHelp());
+        assertTrue(result.getHelpInfo().isPresent());
+        assertTrue(result.getHelpInfo().get().getUrl().contains("file.html"));
+    }
+
+    @Test
+    public void execute_themeCommand_showsHelpWindow() {
+        HelpCommand helpTheme = new HelpCommand("theme");
+        CommandResult result = helpTheme.execute(model);
+        assertTrue(result.isShowHelp());
+        assertTrue(result.getHelpInfo().isPresent());
+        assertTrue(result.getHelpInfo().get().getUrl().contains("set-theme.html"));
+    }
+
+    @Test
+    public void getAvailableCommands_containsAllCommands() {
+        String available = HelpCommand.getAvailableCommands();
+        assertTrue(available.contains("add"));
+        assertTrue(available.contains("delete"));
+        assertTrue(available.contains("file"));
+        assertTrue(available.contains("theme"));
+        assertTrue(available.contains("help"));
+    }
+
+    @Test
+    public void equals() {
+        HelpCommand helpNoArgs = new HelpCommand();
+        HelpCommand helpAdd = new HelpCommand("add");
+        HelpCommand helpAddCopy = new HelpCommand("add");
+        HelpCommand helpDelete = new HelpCommand("delete");
+
+        // same object
+        assertTrue(helpNoArgs.equals(helpNoArgs));
+        assertTrue(helpAdd.equals(helpAdd));
+
+        // same values
+        assertTrue(helpAdd.equals(helpAddCopy));
+
+        // different values
+        assertFalse(helpAdd.equals(helpDelete));
+        assertFalse(helpNoArgs.equals(helpAdd));
+
+        // null
+        assertFalse(helpNoArgs.equals(null));
+
+        // different type
+        assertFalse(helpNoArgs.equals(1));
     }
 }

--- a/src/test/java/seedu/address/logic/commands/HelpInfoTest.java
+++ b/src/test/java/seedu/address/logic/commands/HelpInfoTest.java
@@ -1,0 +1,77 @@
+package seedu.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+public class HelpInfoTest {
+
+    private static final String TEST_MESSAGE = "test message";
+    private static final String TEST_URL = "https://example.com/help";
+
+    @Test
+    public void constructor_validArgs_success() {
+        HelpInfo helpInfo = new HelpInfo(TEST_MESSAGE, TEST_URL);
+        assertEquals(TEST_MESSAGE, helpInfo.getMessage());
+        assertEquals(TEST_URL, helpInfo.getUrl());
+    }
+
+    @Test
+    public void defaultConstant_isNotNull() {
+        assertNotNull(HelpInfo.DEFAULT);
+        assertNotNull(HelpInfo.DEFAULT.getMessage());
+        assertNotNull(HelpInfo.DEFAULT.getUrl());
+        assertTrue(HelpInfo.DEFAULT.getUrl().contains(HelpInfo.USER_GUIDE_BASE_URL));
+    }
+
+    @Test
+    public void equals() {
+        HelpInfo helpInfo = new HelpInfo(TEST_MESSAGE, TEST_URL);
+        HelpInfo helpInfoCopy = new HelpInfo(TEST_MESSAGE, TEST_URL);
+        HelpInfo differentMessage = new HelpInfo("other", TEST_URL);
+        HelpInfo differentUrl = new HelpInfo(TEST_MESSAGE, "https://other.com");
+
+        // same object -> true
+        assertTrue(helpInfo.equals(helpInfo));
+
+        // same values -> true
+        assertTrue(helpInfo.equals(helpInfoCopy));
+
+        // null -> false
+        assertFalse(helpInfo.equals(null));
+
+        // different type -> false
+        assertFalse(helpInfo.equals("string"));
+
+        // different message -> false
+        assertFalse(helpInfo.equals(differentMessage));
+
+        // different url -> false
+        assertFalse(helpInfo.equals(differentUrl));
+    }
+
+    @Test
+    public void hashcode() {
+        HelpInfo helpInfo = new HelpInfo(TEST_MESSAGE, TEST_URL);
+        HelpInfo helpInfoCopy = new HelpInfo(TEST_MESSAGE, TEST_URL);
+        HelpInfo different = new HelpInfo("other", "https://other.com");
+
+        // same values -> same hashcode
+        assertEquals(helpInfo.hashCode(), helpInfoCopy.hashCode());
+
+        // different values -> different hashcode
+        assertNotEquals(helpInfo.hashCode(), different.hashCode());
+    }
+
+    @Test
+    public void toStringMethod() {
+        HelpInfo helpInfo = new HelpInfo(TEST_MESSAGE, TEST_URL);
+        String result = helpInfo.toString();
+        assertTrue(result.contains(TEST_MESSAGE));
+        assertTrue(result.contains(TEST_URL));
+    }
+}


### PR DESCRIPTION
HelpCommand now supports 'help COMMAND' to show usage info for a specific command (e.g. 'help add', 'help delete').

Plain 'help' (no args) still opens the help window as before. Unknown commands show an error with a list of available commands.

Fixes #214