### PR TITLE
Fix parseName crash on empty name input

### DIFF
--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -48,7 +48,11 @@ public class ParserUtil {
      */
     public static Name parseName(String name) throws ParseException {
         requireNonNull(name);
-        String[] splitName = name.trim().split("\\s+");
+        String trimmedName = name.trim();
+        if (trimmedName.isEmpty()) {
+            throw new ParseException(Name.MESSAGE_CONSTRAINTS);
+        }
+        String[] splitName = trimmedName.split("\\s+");
         String titledName = Arrays.stream(splitName)
                 .map(word -> Character.toUpperCase(word.charAt(0)) + word.substring(1).toLowerCase())
                 .collect(Collectors.joining(" "));

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -76,6 +76,16 @@ public class ParserUtilTest {
     }
 
     @Test
+    public void parseName_emptyString_throwsParseException() {
+        assertThrows(ParseException.class, () -> ParserUtil.parseName(""));
+    }
+
+    @Test
+    public void parseName_whitespaceOnly_throwsParseException() {
+        assertThrows(ParseException.class, () -> ParserUtil.parseName("   "));
+    }
+
+    @Test
     public void parseName_validValueWithoutWhitespace_returnsName() throws Exception {
         Name expectedName = new Name(VALID_NAME);
         assertEquals(expectedName, ParserUtil.parseName(VALID_NAME_UNPARSED));


### PR DESCRIPTION
parseName() crashed with StringIndexOutOfBoundsException when given an empty or whitespace-only name, because charAt(0) was called on an empty string before validation.

Add an early empty check that throws ParseException with Name.MESSAGE_CONSTRAINTS before the title-case stream operation.

Fixes #216