### PR TITLE
Fix NoteClearCommand and NoteClearAllCommand success messages

### DIFF
--- a/src/main/java/seedu/address/logic/commands/NoteClearAllCommand.java
+++ b/src/main/java/seedu/address/logic/commands/NoteClearAllCommand.java
@@ -16,7 +16,7 @@ import seedu.address.model.contact.Contact;
  */
 public class NoteClearAllCommand extends NoteCommand {
 
-    public static final String MESSAGE_REMOVE_NOTES_SUCCESS = "Edited note";
+    public static final String MESSAGE_REMOVE_NOTES_SUCCESS = "Cleared all notes";
 
     private final Index index;
 

--- a/src/main/java/seedu/address/logic/commands/NoteClearCommand.java
+++ b/src/main/java/seedu/address/logic/commands/NoteClearCommand.java
@@ -17,7 +17,7 @@ import seedu.address.model.contact.Note;
  */
 public class NoteClearCommand extends NoteCommand {
 
-    public static final String MESSAGE_REMOVE_NOTES_SUCCESS = "Edited note";
+    public static final String MESSAGE_REMOVE_NOTES_SUCCESS = "Cleared %d note(s)";
 
     private final Index index;
     private final int numLines;
@@ -48,6 +48,8 @@ public class NoteClearCommand extends NoteCommand {
         int numExistingLines = newNotes.size();
         newNotes = newNotes.subList(Math.min(numLines, numExistingLines), numExistingLines);
 
+        int numCleared = numExistingLines - newNotes.size();
+
         Contact editedContact = new Contact(contactToEdit.getId(), contactToEdit.getName(),
             contactToEdit.getPhone(), contactToEdit.getEmail(),
             contactToEdit.getAddress(), contactToEdit.getLastContacted(),
@@ -56,7 +58,7 @@ public class NoteClearCommand extends NoteCommand {
         model.setContact(contactToEdit, editedContact);
         model.resetDisplayedContactList();
 
-        String feedback = generateSuccessMessage(editedContact);
+        String feedback = generateSuccessMessage(numCleared, editedContact);
         model.saveSnapshot(feedback);
         return new CommandResult(feedback);
     }
@@ -65,8 +67,9 @@ public class NoteClearCommand extends NoteCommand {
      * Generates a command execution success message.
      * {@code contactToEdit}.
      */
-    private String generateSuccessMessage(Contact contactToEdit) {
-        return Messages.formatNoteOutput(MESSAGE_REMOVE_NOTES_SUCCESS, contactToEdit);
+    private String generateSuccessMessage(int numCleared, Contact contactToEdit) {
+        return Messages.formatNoteOutput(
+                String.format(MESSAGE_REMOVE_NOTES_SUCCESS, numCleared), contactToEdit);
     }
 
     @Override

--- a/src/test/java/seedu/address/logic/commands/NoteClearCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/NoteClearCommandTest.java
@@ -38,7 +38,7 @@ public class NoteClearCommandTest {
                 contactToEdit.getAddress(), contactToEdit.getLastContacted(), NOTES, contactToEdit.getTags());
 
         String expectedMessage = Messages.formatNoteOutput(
-                NoteClearAllCommand.MESSAGE_REMOVE_NOTES_SUCCESS, contactToEdit);
+                String.format(NoteClearCommand.MESSAGE_REMOVE_NOTES_SUCCESS, REMOVE_ONE_LINE), contactToEdit);
         Model testModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
         testModel.setContact(model.getDisplayedContactList().get(0), editedContact);
         testModel.resetDisplayedContactList();


### PR DESCRIPTION
Both commands had MESSAGE_REMOVE_NOTES_SUCCESS = 'Edited note' due to a copy-paste error. Changed to 'Cleared notes' and 'Cleared all notes' respectively.

Also fixed NoteClearCommandTest referencing the wrong class constant.

Fixes #218