### PR TITLE
fix: Fix `Message.format(Contact contact)` to omit "; Tags: " if tags field is empty

### DIFF
--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -21,7 +21,7 @@ public class Messages {
     public static final String MESSAGE_MISSING_KEYWORD = "Missing a keyword";
     public static final String MESSAGE_INVALID_INDEX = "INDEX should be between 1 and %d";
     public static final String MESSAGE_DUPLICATE_FIELDS =
-                "Multiple values specified for the following single-valued field(s): ";
+            "Multiple values specified for the following single-valued field(s): ";
     public static final String MESSAGE_DUPLICATE_TAGS = "Tag names should be unique";
 
     /**
@@ -49,8 +49,10 @@ public class Messages {
             builder.append("; Last Contacted: ");
             builder.append(lastContacted);
         });
-        builder.append("; Tags: ");
-        contact.getTags().forEach(builder::append);
+        if (!contact.getTags().isEmpty()) {
+            builder.append("; Tags: ");
+            contact.getTags().forEach(builder::append);
+        }
         return builder.toString();
     }
 

--- a/src/test/java/seedu/address/logic/MessagesTest.java
+++ b/src/test/java/seedu/address/logic/MessagesTest.java
@@ -50,7 +50,7 @@ public class MessagesTest {
         assertFalse(formatted.contains("; Email:"));
         assertFalse(formatted.contains("; Address:"));
         assertFalse(formatted.contains("; Last Contacted:"));
-        assertTrue(formatted.contains("; Tags:"));
+        assertFalse(formatted.contains("; Tags:"));
     }
 
     @Test


### PR DESCRIPTION
Resolves #227.

**Cause of bug:** `Message.format(Contact contact)` includes "; Tags: " as part of output regardless of whether tags field of `contact` is empty.