### PR TITLE
Fix note clear oldest accepting negative numbers

### DIFF
--- a/src/main/java/seedu/address/logic/parser/NoteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/NoteCommandParser.java
@@ -195,7 +195,12 @@ public class NoteCommandParser implements Parser<NoteCommand> {
      */
     private int parseNumLines(String numLines) throws ParseException {
         try {
-            return Integer.parseInt(numLines);
+            int result = Integer.parseInt(numLines);
+            if (result <= 0) {
+                throw new ParseException(
+                        String.format(MESSAGE_INVALID_COMMAND_FORMAT, NoteAddCommand.MESSAGE_USAGE));
+            }
+            return result;
         } catch (NumberFormatException nfe) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, NoteAddCommand.MESSAGE_USAGE), nfe);
         }

--- a/src/test/java/seedu/address/logic/parser/NoteCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/NoteCommandParserTest.java
@@ -170,6 +170,18 @@ public class NoteCommandParserTest {
     }
 
     @Test
+    public void parse_negativeNumLines_failure() {
+        // negative number of lines for clear oldest
+        assertParseFailure(parser, "1 " + PREFIX_CLEAR_OLDEST + "-5", MESSAGE_INVALID_FORMAT);
+    }
+
+    @Test
+    public void parse_zeroNumLines_failure() {
+        // zero number of lines for clear oldest
+        assertParseFailure(parser, "1 " + PREFIX_CLEAR_OLDEST + "0", MESSAGE_INVALID_FORMAT);
+    }
+
+    @Test
     public void parse_tooManyArguments_failure() {
         // add + clear (preamble is not a single index; index parse fails)
         assertParseFailure(


### PR DESCRIPTION
Validate that numLines is positive in NoteCommandParser.parseNumLines(). Previously, negative values passed through to List.subList() causing IndexOutOfBoundsException.

Fixes #219