### PR TITLE
Fix Note.equals() and hashCode() to include timePoint

### DIFF
--- a/src/main/java/seedu/address/model/contact/Note.java
+++ b/src/main/java/seedu/address/model/contact/Note.java
@@ -4,6 +4,7 @@ import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ON;
 
 import java.time.LocalDateTime;
+import java.util.Objects;
 import java.util.UUID;
 import java.util.regex.Pattern;
 
@@ -126,11 +127,21 @@ public class Note {
 
     @Override
     public boolean equals(Object other) {
-        return other == this || (other instanceof Note && value.equals(((Note) other).value));
+        if (other == this) {
+            return true;
+        }
+        if (!(other instanceof Note)) {
+            return false;
+        }
+        Note otherNote = (Note) other;
+        return value.equals(otherNote.value)
+                && Objects.equals(
+                        timePoint == null ? null : timePoint.toString(),
+                        otherNote.timePoint == null ? null : otherNote.timePoint.toString());
     }
 
     @Override
     public int hashCode() {
-        return value.hashCode();
+        return Objects.hash(value, timePoint == null ? null : timePoint.toString());
     }
 }

--- a/src/test/java/seedu/address/logic/parser/NoteCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/NoteCommandParserTest.java
@@ -13,6 +13,7 @@ import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_NOTE;
 
 import org.junit.jupiter.api.Test;
 
+import seedu.address.commons.core.timepoint.TimePoint;
 import seedu.address.logic.Messages;
 import seedu.address.logic.commands.NoteAddCommand;
 import seedu.address.logic.commands.NoteClearAllCommand;
@@ -50,7 +51,8 @@ public class NoteCommandParserTest {
     @Test
     public void parse_stringReminderNoteAddCommand_success() {
         NoteAddCommand expectedNoteAddCommand =
-                new NoteAddCommand(INDEX_FIRST_CONTACT, new Note(NOTES_STRING));
+                new NoteAddCommand(INDEX_FIRST_CONTACT,
+                        new Note(NOTES_STRING, TimePoint.of("timeString")));
         assertParseSuccess(
                 parser,
                 "1 " + NOTES_STRING + " " + PREFIX_ON + "timeString",
@@ -60,7 +62,9 @@ public class NoteCommandParserTest {
     @Test
     public void parse_dateReminderNoteAddCommand_success() {
         NoteAddCommand expectedNoteAddCommand =
-                new NoteAddCommand(INDEX_FIRST_CONTACT, new Note(NOTES_STRING));
+                new NoteAddCommand(INDEX_FIRST_CONTACT,
+                        new Note(NOTES_STRING,
+                                seedu.address.logic.parser.TimePointParser.toTimePoint("March 11")));
         assertParseSuccess(
                 parser,
                 "1 " + NOTES_STRING + " " + PREFIX_ON + "March 11",
@@ -70,7 +74,9 @@ public class NoteCommandParserTest {
     @Test
     public void parse_datetimeReminderNoteAddCommand_success() {
         NoteAddCommand expectedNoteAddCommand =
-                new NoteAddCommand(INDEX_FIRST_CONTACT, new Note(NOTES_STRING));
+                new NoteAddCommand(INDEX_FIRST_CONTACT,
+                        new Note(NOTES_STRING,
+                                seedu.address.logic.parser.TimePointParser.toTimePoint("March 11 2025 13:30")));
         assertParseSuccess(
                 parser,
                 "1 " + NOTES_STRING + " " + PREFIX_ON + "March 11 2025 13:30",
@@ -121,7 +127,8 @@ public class NoteCommandParserTest {
     @Test
     public void parse_noteEditCommandWithReminder_success() {
         NoteEditCommand expectedNoteEditCommand =
-                new NoteEditCommand(INDEX_FIRST_CONTACT, INDEX_FIRST_NOTE, new Note(NOTES_STRING));
+                new NoteEditCommand(INDEX_FIRST_CONTACT, INDEX_FIRST_NOTE,
+                        new Note(NOTES_STRING, TimePoint.of("timeString")));
         assertParseSuccess(
                 parser,
                 "1 " + PREFIX_EDIT_LINE + "1 " + NOTES_STRING + " " + PREFIX_ON + "timeString",

--- a/src/test/java/seedu/address/model/contact/NoteTest.java
+++ b/src/test/java/seedu/address/model/contact/NoteTest.java
@@ -83,6 +83,30 @@ public class NoteTest {
 
         // different values -> returns false
         assertFalse(notes.equals(new Note("Likes ice cream")));
+
+        // same text, different timePoint -> returns false
+        Note noteWithTime = new Note("To meet on February", TimePoint.of(LocalDate.of(2026, 3, 1)));
+        Note noteWithDiffTime = new Note("To meet on February", TimePoint.of(LocalDate.of(2026, 4, 1)));
+        assertFalse(noteWithTime.equals(noteWithDiffTime));
+
+        // same text, one with timePoint one without -> returns false
+        assertFalse(notes.equals(noteWithTime));
+        assertFalse(noteWithTime.equals(notes));
+
+        // same text and same timePoint -> returns true
+        assertTrue(noteWithTime.equals(new Note("To meet on February", TimePoint.of(LocalDate.of(2026, 3, 1)))));
+    }
+
+    @Test
+    public void hashcode() {
+        Note note1 = new Note("Hello");
+        Note note2 = new Note("Hello");
+        Note noteWithTime1 = new Note("Hello", TimePoint.of(LocalDate.of(2026, 3, 1)));
+        Note noteWithTime2 = new Note("Hello", TimePoint.of(LocalDate.of(2026, 3, 1)));
+
+        // same values -> same hashcode
+        assertEquals(note1.hashCode(), note2.hashCode());
+        assertEquals(noteWithTime1.hashCode(), noteWithTime2.hashCode());
     }
 
     @Test


### PR DESCRIPTION
Note.equals() and hashCode() previously only compared the text value, ignoring the timePoint (reminder) field. This violated the equals/hashCode contract and could cause reminder data to be silently lost in collections.

Now compares timePoint via toString() since TimePoint does not implement equals/hashCode. Updated tests to include timePoint in expected Notes.

Fixes #220