### PR TITLE
Fix Contact.equals() and hashCode() to include notes

### DIFF
--- a/src/main/java/seedu/address/model/contact/Contact.java
+++ b/src/main/java/seedu/address/model/contact/Contact.java
@@ -407,13 +407,14 @@ public class Contact {
                 && email.equals(otherContact.email)
                 && address.equals(otherContact.address)
                 && lastContacted.equals(otherContact.lastContacted)
+                && notes.equals(otherContact.notes)
                 && tags.equals(otherContact.tags);
     }
 
     @Override
     public int hashCode() {
         // use this method for custom fields hashing instead of implementing your own
-        return Objects.hash(name, phone, email, address, lastContacted, tags);
+        return Objects.hash(name, phone, email, address, lastContacted, notes, tags);
     }
 
     @Override

--- a/src/test/data/JsonSerializableAddressBookTest/typicalContactsAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/typicalContactsAddressBook.json
@@ -18,7 +18,7 @@
     "email" : "johnd@example.com",
     "address" : "311, Clementi Ave 2, #02-25",
     "lastUpdated": "2026-02-21T09:00",
-    "notes": [ ],
+    "notes": [ "to meet on/2020 1 may 15:00" ],
     "tags" : [ {
       "type" : "JsonAdaptedTag",
       "name" : "owesMoney"

--- a/src/test/java/seedu/address/model/contact/ContactTest.java
+++ b/src/test/java/seedu/address/model/contact/ContactTest.java
@@ -273,6 +273,10 @@ public class ContactTest {
         // different tags -> returns false
         editedAlice = new ContactBuilder(ALICE).withTags(VALID_TAG_HUSBAND).build();
         assertFalse(ALICE.equals(editedAlice));
+
+        // different notes -> returns false
+        editedAlice = new ContactBuilder(ALICE).withNotes("some different note").build();
+        assertFalse(ALICE.equals(editedAlice));
     }
 
     @Test

--- a/src/test/java/seedu/address/storage/JsonAdaptedContactTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedContactTest.java
@@ -70,7 +70,8 @@ public class JsonAdaptedContactTest {
                         VALID_ID, VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
                         VALID_LAST_CONTACTED, VALID_LAST_UPDATED,
                         "", VALID_TAGS);
-        assertEquals(BENSON, contact.toModelType());
+        Contact expectedContact = new ContactBuilder(BENSON).withNotes().build();
+        assertEquals(expectedContact, contact.toModelType());
     }
 
     @Test


### PR DESCRIPTION
Contact.equals() and hashCode() previously ignored the notes field, meaning two contacts with different notes were considered equal. This could cause note data loss during deduplication or collection operations.

Fixed tests that were incorrectly passing due to the bug.

Fixes #221