### PR TITLE
Fix JsonAdaptedContactTest failures after Note.equals update

### DIFF
--- a/src/test/java/seedu/address/storage/JsonAdaptedContactTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedContactTest.java
@@ -39,7 +39,7 @@ public class JsonAdaptedContactTest {
     private static final Optional<String> VALID_LAST_CONTACTED = BENSON.getLastContacted().map(Object::toString);
     private static final LocalDateTime VALID_LAST_UPDATED = BENSON.getLastUpdated().value;
     private static final List<String> VALID_NOTES = BENSON.getNotes().stream()
-            .map(note -> note.value)
+            .map(note -> note.toJsonString())
             .collect(Collectors.toList());
     private static final String VALID_TAG_NAME = "friends";
     private static final String VALID_TAG_RANK = "best";


### PR DESCRIPTION
VALID_NOTES used `note.value` which drops the timePoint. After Note.equals was updated to include timePoint (#246), deserialized notes without timePoint no longer matched BENSON's notes. Changed to `Note.toJsonString()` to preserve the full round-trip. Fixes 4 test failures.