### PR TITLE
fix: Add ClearCommandParser

### DIFF
--- a/src/main/java/seedu/address/logic/commands/ClearCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ClearCommand.java
@@ -11,6 +11,7 @@ import seedu.address.model.Model;
 public class ClearCommand extends Command {
 
     public static final String COMMAND_WORD = "clear";
+    public static final String MESSAGE_USAGE = "clear: Clears the address book.\nExample: clear";
     public static final String MESSAGE_SUCCESS = "Address book has been cleared!";
 
 
@@ -23,5 +24,10 @@ public class ClearCommand extends Command {
         String feedback = MESSAGE_SUCCESS;
         model.saveSnapshot(feedback);
         return new CommandResult(feedback);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other instanceof ClearCommand;
     }
 }

--- a/src/main/java/seedu/address/logic/commands/HelpCommand.java
+++ b/src/main/java/seedu/address/logic/commands/HelpCommand.java
@@ -33,8 +33,7 @@ public class HelpCommand extends Command {
         COMMAND_HELP_MAP.put(AddCommand.COMMAND_WORD,
                 new HelpInfo(AddCommand.MESSAGE_USAGE, UG_COMMANDS_URL + "add-contact.html"));
         COMMAND_HELP_MAP.put(ClearCommand.COMMAND_WORD,
-                new HelpInfo("clear: Clears the address book.\nExample: clear",
-                        UG_COMMANDS_URL + "clear-contacts.html"));
+                new HelpInfo(ClearCommand.MESSAGE_USAGE, UG_COMMANDS_URL + "clear-contacts.html"));
         COMMAND_HELP_MAP.put(CloseViewCommand.COMMAND_WORD,
                 new HelpInfo(CloseViewCommand.MESSAGE_USAGE,
                         UG_COMMANDS_URL + "close-view-contact.html"));

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -65,7 +65,7 @@ public class AddressBookParser {
             return new AddCommandParser().parse(arguments);
 
         case ClearCommand.COMMAND_WORD:
-            return new ClearCommand();
+            return new ClearCommandParser().parse(arguments);
 
         case CloseViewCommand.COMMAND_WORD:
             if (!arguments.trim().equals(CloseViewCommand.COMMAND_SUBWORD)) {

--- a/src/main/java/seedu/address/logic/parser/ClearCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ClearCommandParser.java
@@ -1,0 +1,23 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import seedu.address.logic.commands.ClearCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+/**
+ * Parses input arguments and creates a new ClearCommand object
+ */
+public class ClearCommandParser implements Parser<ClearCommand> {
+    /**
+     * Checks that the given {@code String} of arguments is empty and returns a ClearCommand object
+     * for execution.
+     * @throws ParseException if the user input does not conform to the expected format
+     */
+    public ClearCommand parse(String args) throws ParseException {
+        if (args.trim().isEmpty()) {
+            return new ClearCommand();
+        }
+        throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, ClearCommand.MESSAGE_USAGE));
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -55,7 +55,6 @@ public class AddressBookParserTest {
     @Test
     public void parseCommand_clear() throws Exception {
         assertTrue(parser.parseCommand(ClearCommand.COMMAND_WORD) instanceof ClearCommand);
-        assertTrue(parser.parseCommand(ClearCommand.COMMAND_WORD + " 3") instanceof ClearCommand);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/ClearCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/ClearCommandParserTest.java
@@ -1,0 +1,24 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.ClearCommand;
+
+public class ClearCommandParserTest {
+    private ClearCommandParser parser = new ClearCommandParser();
+
+    @Test
+    public void parse_noArgs_returnsClearCommand() {
+        assertParseSuccess(parser, "", new ClearCommand());
+        assertParseSuccess(parser, " ", new ClearCommand());
+    }
+
+    @Test
+    public void parseArgs_throwsParseException() {
+        assertParseFailure(parser, "1", String.format(MESSAGE_INVALID_COMMAND_FORMAT, ClearCommand.MESSAGE_USAGE));
+    }
+}

--- a/src/test/java/seedu/address/storage/JsonAdaptedContactTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedContactTest.java
@@ -20,6 +20,7 @@ import seedu.address.model.contact.Email;
 import seedu.address.model.contact.LastContacted;
 import seedu.address.model.contact.LastUpdated;
 import seedu.address.model.contact.Name;
+import seedu.address.model.contact.Note;
 import seedu.address.model.contact.Phone;
 import seedu.address.testutil.ContactBuilder;
 
@@ -39,7 +40,7 @@ public class JsonAdaptedContactTest {
     private static final Optional<String> VALID_LAST_CONTACTED = BENSON.getLastContacted().map(Object::toString);
     private static final LocalDateTime VALID_LAST_UPDATED = BENSON.getLastUpdated().value;
     private static final List<String> VALID_NOTES = BENSON.getNotes().stream()
-            .map(note -> note.value)
+            .map(Note::toJsonString)
             .collect(Collectors.toList());
     private static final String VALID_TAG_NAME = "friends";
     private static final String VALID_TAG_RANK = "best";


### PR DESCRIPTION
Implemented `ClearCommandParser` to only return `ClearCommand` if no arguments were included.

Resolves #226.

Additionally fixed `JsonAdaptedContactTest` failures as unable to build successfully otherwise.