### PR TITLE
Add subsections to UG Command section 

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -121,7 +121,7 @@ To change to a different theme, use the [`theme THEME_NAME`]({{ baseUrl }}/user-
 
 Available themes: [`dark`]({{ baseUrl }}/user-guide/set-theme.html#dark-mode-dark), [`light`]({{ baseUrl }}/user-guide/set-theme.html#light-mode-light), [`book`]({{ baseUrl }}/user-guide/set-theme.html#reading-mode-book), [`sakura`]({{ baseUrl }}/user-guide/set-theme.html#sarkua-mode-sakura)
 
-### Separate data files
+### Maintaining separate data files
 
 B2B4U allows you to maintain multiple separate data files.
 This is useful if you want to maintain separate contact lists for different purposes (e.g. work vs personal contacts).
@@ -140,7 +140,7 @@ To exit B2B4U, use the [`exit`]({{ baseUrl }}/user-guide/exit.html) command.
 B2B4U data is saved to the hard disk automatically after any command that changes the data.
 There is no need to save manually.
 
-### Directly editing the data file
+### Editing the data file directly
 
 B2B4U data is saved automatically as a JSON file `[JAR file location]/data/addressbook.json`.
 Advanced users are welcome to update data directly by editing that data file.

--- a/docs/user-guide/add-contact.md
+++ b/docs/user-guide/add-contact.md
@@ -27,4 +27,4 @@ After a successful `add` command, the contact list will be reset to display ever
 
 A contact is similar if:
 
--
+- <!-- TODO: Explain the similar contact filter the add command uses in further detail -->


### PR DESCRIPTION
**Changes:** Add subsections to the Command section in the UG, which groups certain commands together.

This is intended to simply provide a structure for how the commands should be documented in the UG, with demonstration of certain ideas we should utilise:
- Grouping certain commands that are strongly relevant together rather than having each command be a separate section
- Utilise linking between the UG and the command subpages where users can gain additional information regarding the details of the command
- Utilise linking to the titles/sections of the subpages rather than the entire page as even the subpage can get lengthy once we add further detail/pictures, thus linking to the specific section can assist in swifter navigation.
As such a few of the sections are still empty and open for others to make changes to with their own PRs. This PR is meant to only decide upon the overall structure of the UG going forward with regards to how the commands should be documented in the main UserGuide.md document.