### PR TITLE
fix: Save theme as command word

### DIFF
--- a/src/main/java/seedu/address/MainApp.java
+++ b/src/main/java/seedu/address/MainApp.java
@@ -10,8 +10,10 @@ import javafx.application.Application;
 import javafx.stage.Stage;
 import seedu.address.commons.core.Config;
 import seedu.address.commons.core.LogsCenter;
+import seedu.address.commons.core.Themes;
 import seedu.address.commons.core.Version;
 import seedu.address.commons.exceptions.DataLoadingException;
+import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.commons.util.ConfigUtil;
 import seedu.address.commons.util.StringUtil;
 import seedu.address.logic.Logic;
@@ -174,11 +176,16 @@ public class MainApp extends Application {
             Optional<UserPrefs> prefsOptional = storage.readUserPrefs();
             if (!prefsOptional.isPresent()) {
                 logger.info("Creating new preference file " + prefsFilePath);
+            } else if (!Themes.contains(prefsOptional.get().getTheme())) {
+                throw new IllegalValueException("Invalid theme: " + prefsOptional.get().getTheme());
             }
             initializedPrefs = prefsOptional.orElse(new UserPrefs());
         } catch (DataLoadingException e) {
             logger.warning("Preference file at " + prefsFilePath + " could not be loaded."
                     + " Using default preferences.");
+            initializedPrefs = new UserPrefs();
+        } catch (IllegalValueException e) {
+            logger.warning("Illegal value found in " + prefsFilePath + ": " + e.getMessage());
             initializedPrefs = new UserPrefs();
         }
 

--- a/src/main/java/seedu/address/commons/core/GuiSettings.java
+++ b/src/main/java/seedu/address/commons/core/GuiSettings.java
@@ -5,7 +5,6 @@ import java.io.Serializable;
 import java.util.Objects;
 
 import seedu.address.commons.util.ToStringBuilder;
-import seedu.address.ui.UiUtil;
 
 /**
  * A Serializable class that contains the GUI settings.
@@ -15,12 +14,13 @@ public class GuiSettings implements Serializable {
 
     private static final double DEFAULT_HEIGHT = 600;
     private static final double DEFAULT_WIDTH = 740;
+    private static final String DEFAULT_THEME = "dark";
 
     private final double windowWidth;
     private final double windowHeight;
     private final Point windowCoordinates;
 
-    private final String themeUrl;
+    private final String theme;
 
     /**
      * Constructs a {@code GuiSettings} with the default height, width and position.
@@ -29,27 +29,27 @@ public class GuiSettings implements Serializable {
         windowWidth = DEFAULT_WIDTH;
         windowHeight = DEFAULT_HEIGHT;
         windowCoordinates = null; // null represent no coordinates
-        themeUrl = UiUtil.getUrl("DarkTheme.css").toString();
+        theme = DEFAULT_THEME;
     }
 
     /**
      * Constructs a {@code GuiSettings} with the specified height, width and theme.
      */
-    public GuiSettings(double windowWidth, double windowHeight, String themeUrl) {
+    public GuiSettings(double windowWidth, double windowHeight, String theme) {
         this.windowWidth = windowWidth;
         this.windowHeight = windowHeight;
         windowCoordinates = null;
-        this.themeUrl = themeUrl;
+        this.theme = theme;
     }
 
     /**
      * Constructs a {@code GuiSettings} with the specified height, width, position and theme.
      */
-    public GuiSettings(double windowWidth, double windowHeight, int xPosition, int yPosition, String themeUrl) {
+    public GuiSettings(double windowWidth, double windowHeight, int xPosition, int yPosition, String theme) {
         this.windowWidth = windowWidth;
         this.windowHeight = windowHeight;
         windowCoordinates = new Point(xPosition, yPosition);
-        this.themeUrl = themeUrl;
+        this.theme = theme;
     }
 
     public double getWindowWidth() {
@@ -64,8 +64,8 @@ public class GuiSettings implements Serializable {
         return windowCoordinates != null ? new Point(windowCoordinates) : null;
     }
 
-    public String getThemeUrl() {
-        return themeUrl;
+    public String getTheme() {
+        return theme;
     }
 
     @Override
@@ -87,7 +87,7 @@ public class GuiSettings implements Serializable {
 
     @Override
     public int hashCode() {
-        return Objects.hash(windowWidth, windowHeight, windowCoordinates, themeUrl);
+        return Objects.hash(windowWidth, windowHeight, windowCoordinates, theme);
     }
 
     @Override
@@ -96,7 +96,7 @@ public class GuiSettings implements Serializable {
                 .add("windowWidth", windowWidth)
                 .add("windowHeight", windowHeight)
                 .add("windowCoordinates", windowCoordinates)
-                .add("theme", themeUrl)
+                .add("theme", theme)
                 .toString();
     }
 }

--- a/src/main/java/seedu/address/commons/core/Themes.java
+++ b/src/main/java/seedu/address/commons/core/Themes.java
@@ -11,6 +11,7 @@ import seedu.address.ui.UiUtil;
  */
 public final class Themes {
     public static final String AVAILABLE_THEMES_MESSAGE = "Available themes: dark, light, book, sakura";
+    public static final String DEFAULT_THEME = UiUtil.getUrl("DarkTheme.css").toString();
 
     private static final Map<String, String> AVAILABLE_THEMES;
 

--- a/src/main/java/seedu/address/logic/Logic.java
+++ b/src/main/java/seedu/address/logic/Logic.java
@@ -49,9 +49,9 @@ public interface Logic {
     void setGuiSettings(GuiSettings guiSettings);
 
     /**
-     * Returns the current user prefs' theme URL.
+     * Returns the current user prefs' theme.
      */
-    String getThemeUrl();
+    String getTheme();
 
     /**
      * Returns true if there exists previous snapshots for the model to undo towards.

--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -94,8 +94,8 @@ public class LogicManager implements Logic {
     }
 
     @Override
-    public String getThemeUrl() {
-        return model.getThemeUrl();
+    public String getTheme() {
+        return model.getTheme();
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/FileDeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FileDeleteCommand.java
@@ -55,7 +55,7 @@ public class FileDeleteCommand extends FileCommand {
                 DeleteFileAlert alert =
                         new DeleteFileAlert(filePath.getFileName().toString(),
                                 addressBookOptional.get().getContactList().size(),
-                                model.getThemeUrl());
+                                model.getTheme());
                 alert.show();
 
                 if (!(alert.getResult() == ButtonType.YES)) {

--- a/src/main/java/seedu/address/logic/commands/ThemeCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ThemeCommand.java
@@ -31,7 +31,7 @@ public class ThemeCommand extends Command {
 
     @Override
     public CommandResult execute(Model model) throws CommandException {
-        model.setThemeUrl(Themes.get(key));
+        model.setTheme(key);
 
         String feedback = String.format(MESSAGE_SUCCESS, key);
         model.saveSnapshot(feedback);

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -33,14 +33,14 @@ public interface Model {
     void setGuiSettings(GuiSettings guiSettings);
 
     /**
-     * Returns the current user prefs' theme URL.
+     * Returns the current user prefs' theme.
      */
-    String getThemeUrl();
+    String getTheme();
 
     /**
-     * Sets the current user prefs' theme URL.
+     * Sets the current user prefs' theme.
      */
-    void setThemeUrl(String themeUrl);
+    void setTheme(String theme);
 
     /**
      * Returns the user prefs' address book file path.

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -93,13 +93,13 @@ public class ModelManager implements Model {
     }
 
     @Override
-    public String getThemeUrl() {
-        return userPrefs.getThemeUrl();
+    public String getTheme() {
+        return userPrefs.getTheme();
     }
 
     @Override
-    public void setThemeUrl(String themeUrl) {
-        userPrefs.setThemeUrl(themeUrl);
+    public void setTheme(String theme) {
+        userPrefs.setTheme(theme);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/UserPrefs.java
+++ b/src/main/java/seedu/address/model/UserPrefs.java
@@ -50,12 +50,12 @@ public class UserPrefs implements ReadOnlyUserPrefs {
         this.guiSettings = guiSettings;
     }
 
-    public String getThemeUrl() {
-        return guiSettings.getThemeUrl();
+    public String getTheme() {
+        return guiSettings.getTheme();
     }
 
-    public void setThemeUrl(String themeUrl) {
-        this.guiSettings = new GuiSettings(guiSettings.getWindowWidth(), guiSettings.getWindowHeight(), themeUrl);
+    public void setTheme(String theme) {
+        this.guiSettings = new GuiSettings(guiSettings.getWindowWidth(), guiSettings.getWindowHeight(), theme);
     }
 
     public Path getAddressBookFilePath() {

--- a/src/main/java/seedu/address/ui/DeleteFileAlert.java
+++ b/src/main/java/seedu/address/ui/DeleteFileAlert.java
@@ -8,6 +8,7 @@ import javafx.scene.control.ButtonType;
 import javafx.scene.control.Label;
 import javafx.stage.Modality;
 import javafx.stage.Stage;
+import seedu.address.commons.core.Themes;
 
 /**
  * Alerts the user of the deletion of a file containing data and requests for confirmation.
@@ -29,15 +30,15 @@ public class DeleteFileAlert extends UiPart<Stage> {
      * Creates a new DeleteFileAlert window.
      * @param root Stage to use as the root of the DeleteFileAlert window.
      * @param alertText Text to display to user.
-     * @param themeUrl URL of theme to be used for this alert window.
+     * @param theme Theme to be used for this alert window.
      */
-    public DeleteFileAlert(Stage root, String alertText, String themeUrl) {
+    public DeleteFileAlert(Stage root, String alertText, String theme) {
         super(FXML, root);
 
         List<String> essentialStylesheets = root.getScene().getStylesheets();
         String[] stylesheets = new String[essentialStylesheets.size() + 1];
         essentialStylesheets.toArray(stylesheets);
-        stylesheets[stylesheets.length - 1] = themeUrl;
+        stylesheets[stylesheets.length - 1] = Themes.get(theme);
         root.getScene().getStylesheets().setAll(stylesheets);
 
         alertLabel.setText(alertText);
@@ -48,8 +49,8 @@ public class DeleteFileAlert extends UiPart<Stage> {
      * @param fileName Name of file to be deleted.
      * @param contactCount Number of contacts within file to be deleted.
      */
-    public DeleteFileAlert(String fileName, int contactCount, String themeUrl) {
-        this(new Stage(), String.format(ALERT_FORMAT, fileName, contactCount), themeUrl);
+    public DeleteFileAlert(String fileName, int contactCount, String theme) {
+        this(new Stage(), String.format(ALERT_FORMAT, fileName, contactCount), theme);
     }
 
     /**

--- a/src/main/java/seedu/address/ui/HelpWindow.java
+++ b/src/main/java/seedu/address/ui/HelpWindow.java
@@ -10,6 +10,7 @@ import javafx.scene.input.Clipboard;
 import javafx.scene.input.ClipboardContent;
 import javafx.stage.Stage;
 import seedu.address.commons.core.LogsCenter;
+import seedu.address.commons.core.Themes;
 import seedu.address.logic.commands.HelpInfo;
 
 /**
@@ -122,10 +123,10 @@ public class HelpWindow extends UiPart<Stage> {
 
     /**
      * Sets the theme of the HelpWindow.
-     * @param themeUrl URL of the desired theme.
+     * @param theme The desired theme.
      */
-    public void setTheme(String themeUrl) {
-        stylesheets[stylesheets.length - 1] = themeUrl;
+    public void setTheme(String theme) {
+        stylesheets[stylesheets.length - 1] = Themes.get(theme);
         stage.getScene().getStylesheets().setAll(stylesheets);
     }
 }

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -20,6 +20,7 @@ import javafx.scene.layout.VBox;
 import javafx.stage.Stage;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.LogsCenter;
+import seedu.address.commons.core.Themes;
 import seedu.address.logic.Logic;
 import seedu.address.logic.commands.AddCommand;
 import seedu.address.logic.commands.CommandResult;
@@ -196,7 +197,7 @@ public class MainWindow extends UiPart<Stage> {
 
         if (logic.getDisplayedContactList().stream().anyMatch(Contact::hasDueReminders)) {
             reminderWindow = new ReminderWindow(logic.getDisplayedContactList());
-            reminderWindow.setTheme(logic.getThemeUrl());
+            reminderWindow.setTheme(logic.getTheme());
             reminderWindow.show();
         }
 
@@ -266,14 +267,14 @@ public class MainWindow extends UiPart<Stage> {
 
     /**
      * Sets the theme of the MainWindow.
-     * @param themeUrl URL of the desired theme.
+     * @param theme The desired theme.
      */
-    public void setTheme(String themeUrl) {
-        stylesheets[stylesheets.length - 1] = themeUrl;
+    public void setTheme(String theme) {
+        stylesheets[stylesheets.length - 1] = Themes.get(theme);
         primaryStage.getScene().getStylesheets().setAll(stylesheets);
-        helpWindow.setTheme(themeUrl);
+        helpWindow.setTheme(theme);
         if (reminderWindow != null) {
-            reminderWindow.setTheme(themeUrl);
+            reminderWindow.setTheme(theme);
         }
     }
 
@@ -358,7 +359,7 @@ public class MainWindow extends UiPart<Stage> {
     }
 
     void show() {
-        setTheme(logic.getThemeUrl());
+        setTheme(logic.getTheme());
 
         primaryStage.show();
     }
@@ -369,7 +370,7 @@ public class MainWindow extends UiPart<Stage> {
     @FXML
     private void handleExit() {
         GuiSettings guiSettings = new GuiSettings(primaryStage.getWidth(), primaryStage.getHeight(),
-                (int) primaryStage.getX(), (int) primaryStage.getY(), logic.getThemeUrl());
+                (int) primaryStage.getX(), (int) primaryStage.getY(), logic.getTheme());
         logic.setGuiSettings(guiSettings);
         helpWindow.hide();
         primaryStage.hide();
@@ -508,8 +509,8 @@ public class MainWindow extends UiPart<Stage> {
                 contactListPanel.scrollToBottom();
             }
 
-            if (!logic.getThemeUrl().equals(stylesheets[stylesheets.length - 1])) {
-                setTheme(logic.getThemeUrl());
+            if (!logic.getTheme().equals(stylesheets[stylesheets.length - 1])) {
+                setTheme(logic.getTheme());
             }
             statusBarFooter.updateSaveLocation(logic.getAddressBookFilePath());
             undoMenuItem.setDisable(!logic.modelCanUndo());

--- a/src/main/java/seedu/address/ui/ReminderWindow.java
+++ b/src/main/java/seedu/address/ui/ReminderWindow.java
@@ -8,6 +8,7 @@ import javafx.scene.control.Label;
 import javafx.scene.layout.VBox;
 import javafx.stage.Stage;
 import seedu.address.commons.core.LogsCenter;
+import seedu.address.commons.core.Themes;
 import seedu.address.model.contact.Contact;
 import seedu.address.model.contact.Note;
 
@@ -116,10 +117,10 @@ public class ReminderWindow extends UiPart<Stage> {
 
     /**
      * Sets the theme of the ReminderWindow.
-     * @param themeUrl URL of the desired theme.
+     * @param theme The desired theme.
      */
-    public void setTheme(String themeUrl) {
-        stylesheets[stylesheets.length - 1] = themeUrl;
+    public void setTheme(String theme) {
+        stylesheets[stylesheets.length - 1] = Themes.get(theme);
         stage.getScene().getStylesheets().setAll(stylesheets);
     }
 }

--- a/src/test/java/seedu/address/commons/core/GuiSettingsTest.java
+++ b/src/test/java/seedu/address/commons/core/GuiSettingsTest.java
@@ -11,7 +11,7 @@ public class GuiSettingsTest {
         String expected = GuiSettings.class.getCanonicalName() + "{windowWidth=" + guiSettings.getWindowWidth()
                 + ", windowHeight=" + guiSettings.getWindowHeight() + ", windowCoordinates="
                 + guiSettings.getWindowCoordinates() + ", theme="
-                + guiSettings.getThemeUrl() + "}";
+                + guiSettings.getTheme() + "}";
         assertEquals(expected, guiSettings.toString());
     }
 }

--- a/src/test/java/seedu/address/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/address/logic/LogicManagerTest.java
@@ -34,7 +34,6 @@ import seedu.address.storage.JsonAddressBookStorage;
 import seedu.address.storage.JsonUserPrefsStorage;
 import seedu.address.storage.StorageManager;
 import seedu.address.testutil.ContactBuilder;
-import seedu.address.ui.UiUtil;
 
 public class LogicManagerTest {
     private static final IOException DUMMY_IO_EXCEPTION = new IOException("dummy IO exception");
@@ -193,7 +192,7 @@ public class LogicManagerTest {
     }
 
     @Test
-    public void getThemeUrlTest() {
-        assertEquals(UiUtil.getUrl("DarkTheme.css").toString(), logic.getThemeUrl());
+    public void getThemeTest() {
+        assertEquals("dark", logic.getTheme());
     }
 }

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -111,12 +111,12 @@ public class AddCommandTest {
         }
 
         @Override
-        public String getThemeUrl() {
+        public String getTheme() {
             throw new AssertionError("This method should not be called.");
         }
 
         @Override
-        public void setThemeUrl(String themeUrl) {
+        public void setTheme(String theme) {
             //no-op for testing
         }
 

--- a/src/test/java/seedu/address/logic/commands/ThemeCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ThemeCommandTest.java
@@ -7,14 +7,11 @@ import static seedu.address.testutil.Assert.assertThrows;
 
 import org.junit.jupiter.api.Test;
 
-import seedu.address.commons.core.Themes;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
 
 public class ThemeCommandTest {
-    private static final String DARK_THEME = Themes.get("dark");
-    private static final String LIGHT_THEME = Themes.get("light");
 
     @Test
     public void invalidTheme_failure() {
@@ -28,7 +25,7 @@ public class ThemeCommandTest {
         String expectedMessage = String.format(ThemeCommand.MESSAGE_SUCCESS, "light");
         Model expectedModel = new ModelManager();
         UserPrefs expectedUserPrefs = new UserPrefs();
-        expectedUserPrefs.setThemeUrl(Themes.get("light"));
+        expectedUserPrefs.setTheme("light");
         assertCommandSuccess(themeCommand, model, expectedMessage, expectedModel);
     }
 

--- a/src/test/java/seedu/address/model/ModelManagerTest.java
+++ b/src/test/java/seedu/address/model/ModelManagerTest.java
@@ -14,16 +14,13 @@ import java.util.Arrays;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.commons.core.GuiSettings;
-import seedu.address.commons.core.Themes;
 import seedu.address.model.contact.Contact;
 import seedu.address.model.contact.ContactFieldComparator;
 import seedu.address.model.contact.util.ContactPredicateBuilder;
 import seedu.address.testutil.AddressBookBuilder;
 import seedu.address.testutil.ContactBuilder;
-import seedu.address.ui.UiUtil;
 
 public class ModelManagerTest {
-    private static final String DARK_THEME = Themes.get("dark");
 
     private ModelManager modelManager = new ModelManager();
 
@@ -43,7 +40,7 @@ public class ModelManagerTest {
     public void setUserPrefs_validUserPrefs_copiesUserPrefs() {
         UserPrefs userPrefs = new UserPrefs();
         userPrefs.setAddressBookFilePath(Paths.get("address/book/file/path"));
-        userPrefs.setGuiSettings(new GuiSettings(1, 2, 3, 4, DARK_THEME));
+        userPrefs.setGuiSettings(new GuiSettings(1, 2, 3, 4, "dark"));
         modelManager.setUserPrefs(userPrefs);
         assertEquals(userPrefs, modelManager.getUserPrefs());
 
@@ -60,14 +57,14 @@ public class ModelManagerTest {
 
     @Test
     public void setGuiSettings_validGuiSettings_setsGuiSettings() {
-        GuiSettings guiSettings = new GuiSettings(1, 2, 3, 4, DARK_THEME);
+        GuiSettings guiSettings = new GuiSettings(1, 2, 3, 4, "dark");
         modelManager.setGuiSettings(guiSettings);
         assertEquals(guiSettings, modelManager.getGuiSettings());
     }
 
     @Test
-    public void getThemeUrlTest() {
-        assertEquals(UiUtil.getUrl("DarkTheme.css").toString(), modelManager.getThemeUrl());
+    public void getThemeTest() {
+        assertEquals("dark", modelManager.getTheme());
     }
 
     @Test

--- a/src/test/java/seedu/address/model/UserPrefsTest.java
+++ b/src/test/java/seedu/address/model/UserPrefsTest.java
@@ -9,8 +9,6 @@ import java.nio.file.Paths;
 
 import org.junit.jupiter.api.Test;
 
-import seedu.address.ui.UiUtil;
-
 public class UserPrefsTest {
 
     @Test
@@ -26,9 +24,9 @@ public class UserPrefsTest {
     }
 
     @Test
-    public void getThemeUrlTest() {
+    public void getThemeTest() {
         UserPrefs userPrefs = new UserPrefs();
-        assertEquals(UiUtil.getUrl("DarkTheme.css").toString(), userPrefs.getThemeUrl());
+        assertEquals("dark", userPrefs.getTheme());
     }
 
     @Test

--- a/src/test/java/seedu/address/storage/JsonUserPrefsStorageTest.java
+++ b/src/test/java/seedu/address/storage/JsonUserPrefsStorageTest.java
@@ -13,12 +13,10 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import seedu.address.commons.core.GuiSettings;
-import seedu.address.commons.core.Themes;
 import seedu.address.commons.exceptions.DataLoadingException;
 import seedu.address.model.UserPrefs;
 
 public class JsonUserPrefsStorageTest {
-    private static final String DARK_THEME = Themes.get("dark");
 
     private static final Path TEST_DATA_FOLDER = Paths.get("src", "test", "data", "JsonUserPrefsStorageTest");
 
@@ -74,7 +72,7 @@ public class JsonUserPrefsStorageTest {
 
     private UserPrefs getTypicalUserPrefs() {
         UserPrefs userPrefs = new UserPrefs();
-        userPrefs.setGuiSettings(new GuiSettings(1000, 500, 300, 100, DARK_THEME));
+        userPrefs.setGuiSettings(new GuiSettings(1000, 500, 300, 100, "dark"));
         userPrefs.setAddressBookFilePath(Paths.get("addressbook.json"));
         return userPrefs;
     }
@@ -105,7 +103,7 @@ public class JsonUserPrefsStorageTest {
     public void saveUserPrefs_allInOrder_success() throws DataLoadingException, IOException {
 
         UserPrefs original = new UserPrefs();
-        original.setGuiSettings(new GuiSettings(1200, 200, 0, 2, DARK_THEME));
+        original.setGuiSettings(new GuiSettings(1200, 200, 0, 2, "dark"));
 
         Path pefsFilePath = testFolder.resolve("TempPrefs.json");
         JsonUserPrefsStorage jsonUserPrefsStorage = new JsonUserPrefsStorage(pefsFilePath);
@@ -116,7 +114,7 @@ public class JsonUserPrefsStorageTest {
         assertEquals(original, readBack);
 
         //Try saving when the file exists
-        original.setGuiSettings(new GuiSettings(5, 5, 5, 5, DARK_THEME));
+        original.setGuiSettings(new GuiSettings(5, 5, 5, 5, "dark"));
         jsonUserPrefsStorage.saveUserPrefs(original);
         readBack = jsonUserPrefsStorage.readUserPrefs().get();
         assertEquals(original, readBack);

--- a/src/test/java/seedu/address/storage/StorageManagerTest.java
+++ b/src/test/java/seedu/address/storage/StorageManagerTest.java
@@ -11,14 +11,11 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import seedu.address.commons.core.GuiSettings;
-import seedu.address.commons.core.Themes;
 import seedu.address.model.AddressBook;
 import seedu.address.model.ReadOnlyAddressBook;
 import seedu.address.model.UserPrefs;
 
 public class StorageManagerTest {
-    private static final String DARK_THEME = Themes.get("dark");
-
     @TempDir
     public Path testFolder;
 
@@ -43,7 +40,7 @@ public class StorageManagerTest {
          * More extensive testing of UserPref saving/reading is done in {@link JsonUserPrefsStorageTest} class.
          */
         UserPrefs original = new UserPrefs();
-        original.setGuiSettings(new GuiSettings(300, 600, 4, 6, DARK_THEME));
+        original.setGuiSettings(new GuiSettings(300, 600, 4, 6, "dark"));
         storageManager.saveUserPrefs(original);
         UserPrefs retrieved = storageManager.readUserPrefs().get();
         assertEquals(original, retrieved);

--- a/src/test/java/seedu/address/ui/DeleteFileAlertTest.java
+++ b/src/test/java/seedu/address/ui/DeleteFileAlertTest.java
@@ -11,7 +11,7 @@ public class DeleteFileAlertTest extends GuiUnitTest {
     public void construct_success() throws Exception {
         runAndWait(() -> {
             Stage stage = new Stage();
-            alert = new DeleteFileAlert(stage, "Message", "stubTheme");
+            alert = new DeleteFileAlert(stage, "Message", "light");
         });
     }
 }

--- a/src/test/java/seedu/address/ui/MainWindowTest.java
+++ b/src/test/java/seedu/address/ui/MainWindowTest.java
@@ -110,8 +110,9 @@ public class MainWindowTest extends GuiUnitTest {
     @Test
     public void setThemeTest() throws Exception {
         runAndWait(() -> {
-            mainWindow.setTheme("stubTheme");
-            assert mainWindow.getPrimaryStage().getScene().getStylesheets().contains("stubTheme");
+            mainWindow.setTheme("light");
+            assert mainWindow.getPrimaryStage().getScene().getStylesheets()
+                    .contains(UiUtil.getUrl("LightTheme.css").toString());
         });
     }
 
@@ -180,7 +181,7 @@ public class MainWindowTest extends GuiUnitTest {
 
         @Override
         public String getTheme() {
-            return "theme";
+            return "dark";
         }
 
         @Override

--- a/src/test/java/seedu/address/ui/MainWindowTest.java
+++ b/src/test/java/seedu/address/ui/MainWindowTest.java
@@ -179,7 +179,7 @@ public class MainWindowTest extends GuiUnitTest {
         }
 
         @Override
-        public String getThemeUrl() {
+        public String getTheme() {
             return "theme";
         }
 

--- a/src/test/java/seedu/address/ui/ReminderWindowTest.java
+++ b/src/test/java/seedu/address/ui/ReminderWindowTest.java
@@ -21,8 +21,9 @@ public class ReminderWindowTest extends GuiUnitTest {
     @Test
     public void setThemeTest() throws Exception {
         runAndWait(() -> {
-            reminderWindow.setTheme("stubTheme");
-            assert reminderWindow.getStage().getScene().getStylesheets().contains("stubTheme");
+            reminderWindow.setTheme("light");
+            assert reminderWindow.getStage().getScene().getStylesheets()
+                    .contains(UiUtil.getUrl("LightTheme.css").toString());
         });
     }
 }


### PR DESCRIPTION
`Theme` is now saved as its command word in `preferences.json` rather than as the css file path.

If `preferences.json` has been modified in a way which results in an invalid theme, a new `UserPrefs` will be created on initialization.