### PR TITLE
fix: Make notes section of contact card scrollable, add indexes to notes section in Contact Detail Panel

### DIFF
--- a/src/main/java/seedu/address/ui/ContactCard.java
+++ b/src/main/java/seedu/address/ui/ContactCard.java
@@ -5,6 +5,7 @@ import java.util.Comparator;
 import javafx.collections.ObservableList;
 import javafx.fxml.FXML;
 import javafx.scene.control.Label;
+import javafx.scene.control.ScrollPane;
 import javafx.scene.layout.FlowPane;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.Region;
@@ -47,6 +48,8 @@ public class ContactCard extends UiPart<Region> {
     @FXML
     private VBox notesContainer;
     @FXML
+    private ScrollPane notesScrollPane;
+    @FXML
     private FlowPane tags;
 
     /**
@@ -82,9 +85,7 @@ public class ContactCard extends UiPart<Region> {
         UiUtil.show(this.lastUpdated);
         if (!(contact.getNotes().isEmpty())) {
             NotesTextFlow notes = new NotesTextFlow(contact.getNotes(), allContacts);
-            notes.setNewMaxHeight(notesContainer.getMaxHeight()
-                    - (notesContainer.getPadding().getTop() + notesContainer.getPadding().getBottom()));
-            notesContainer.getChildren().add(notes);
+            notesScrollPane.setContent(notes);
         } else {
             UiUtil.hide(notesContainer);
         }

--- a/src/main/java/seedu/address/ui/ContactDetailPanel.java
+++ b/src/main/java/seedu/address/ui/ContactDetailPanel.java
@@ -5,8 +5,8 @@ import java.util.Comparator;
 import javafx.collections.ObservableList;
 import javafx.fxml.FXML;
 import javafx.scene.control.Label;
-import javafx.scene.control.ScrollPane;
 import javafx.scene.layout.FlowPane;
+import javafx.scene.layout.HBox;
 import javafx.scene.layout.Region;
 import javafx.scene.layout.VBox;
 import seedu.address.commons.core.timepoint.DateTimeUtil;
@@ -34,8 +34,6 @@ public class ContactDetailPanel extends UiPart<Region> {
     @FXML
     private Label lastUpdated;
     @FXML
-    private ScrollPane notesScrollPane;
-    @FXML
     private FlowPane tags;
     @FXML
     private VBox tagsContainer;
@@ -51,6 +49,8 @@ public class ContactDetailPanel extends UiPart<Region> {
     private VBox lastUpdatedContainer;
     @FXML
     private VBox notesContainer;
+    @FXML
+    private VBox notes;
 
     private ObservableList<Contact> allContacts;
 
@@ -112,9 +112,14 @@ public class ContactDetailPanel extends UiPart<Region> {
 
         // Notes
         if (!contact.getNotes().isEmpty()) {
-            NotesTextFlow notesTextFlow = new NotesTextFlow(contact.getNotes(), allContacts);
-            notesTextFlow.addStyleClass("detail-text-flow");
-            notesScrollPane.setContent(notesTextFlow);
+            contact.getNotes()
+                    .forEach(note -> {
+                        NoteLabel noteLabel = new NoteLabel(note, notes.getStyleClass().toString(), allContacts);
+                        noteLabel.hideHeader();
+                        Label indexLabel = new Label((notes.getChildren().size() + 1) + ". ");
+                        indexLabel.getStyleClass().add("note-index-label");
+                        HBox indexedNoteLabel = new HBox(indexLabel, noteLabel);
+                        notes.getChildren().add(indexedNoteLabel); });
             UiUtil.show(notesContainer);
         } else {
             UiUtil.hide(notesContainer);

--- a/src/main/java/seedu/address/ui/ContactDetailPanel.java
+++ b/src/main/java/seedu/address/ui/ContactDetailPanel.java
@@ -112,6 +112,7 @@ public class ContactDetailPanel extends UiPart<Region> {
 
         // Notes
         if (!contact.getNotes().isEmpty()) {
+            notes.getChildren().clear();
             contact.getNotes()
                     .forEach(note -> {
                         NoteLabel noteLabel = new NoteLabel(note, notes.getStyleClass().toString(), allContacts);

--- a/src/main/resources/view/ContactDetailPanel.fxml
+++ b/src/main/resources/view/ContactDetailPanel.fxml
@@ -6,7 +6,6 @@
 <?import javafx.scene.layout.FlowPane?>
 <?import javafx.scene.layout.HBox?>
 <?import javafx.scene.layout.VBox?>
-<?import javafx.scene.text.TextFlow?>
 
 <VBox fx:id="detailPane" styleClass="contact-detail-panel" xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1">
     <padding>
@@ -85,7 +84,7 @@
             <Insets bottom="10" />
         </padding>
         <Label styleClass="detail-label" text="Notes:" />
-        <ScrollPane fx:id="notesScrollPane" fitToWidth="true" vbarPolicy="ALWAYS" VBox.vgrow="ALWAYS">
+        <ScrollPane fx:id="notesScrollPane" fitToWidth="true" VBox.vgrow="ALWAYS">
             <content>
             </content>
         </ScrollPane>

--- a/src/main/resources/view/ContactDetailPanel.fxml
+++ b/src/main/resources/view/ContactDetailPanel.fxml
@@ -20,73 +20,76 @@
         <Label fx:id="name" styleClass="detail-name" text="\$name" />
     </HBox>
 
-    <!-- Tags -->
-    <VBox fx:id="tagsContainer" styleClass="detail-section">
-        <padding>
-            <Insets bottom="10" />
-        </padding>
-        <Label styleClass="detail-label" text="Tags:" />
-        <FlowPane fx:id="tags" hgap="5" vgap="5">
-            <padding>
-                <Insets top="5" />
-            </padding>
-        </FlowPane>
-    </VBox>
+    <ScrollPane fitToWidth="true" VBox.vgrow="ALWAYS">
+        <VBox styleClass="detail-section" VBox.vgrow="ALWAYS">
+            <!-- Tags -->
+            <VBox fx:id="tagsContainer" styleClass="detail-section">
+                <padding>
+                    <Insets bottom="10" />
+                </padding>
+                <Label styleClass="detail-label" text="Tags:" />
+                <FlowPane fx:id="tags" hgap="5" vgap="5">
+                    <padding>
+                        <Insets top="5" />
+                    </padding>
+                </FlowPane>
+            </VBox>
 
-    <!-- Phone -->
-    <VBox fx:id="phoneContainer" styleClass="detail-section">
-        <padding>
-            <Insets bottom="10" />
-        </padding>
-        <Label styleClass="detail-label" text="Phone:" />
-        <Label fx:id="phone" styleClass="detail-value" text="\$phone" />
-    </VBox>
+            <!-- Phone -->
+            <VBox fx:id="phoneContainer" styleClass="detail-section">
+                <padding>
+                    <Insets bottom="10" />
+                </padding>
+                <Label styleClass="detail-label" text="Phone:" />
+                <Label fx:id="phone" styleClass="detail-value" text="\$phone" />
+            </VBox>
 
-    <!-- Email -->
-    <VBox fx:id="emailContainer" styleClass="detail-section">
-        <padding>
-            <Insets bottom="10" />
-        </padding>
-        <Label styleClass="detail-label" text="Email:" />
-        <Label fx:id="email" styleClass="detail-value" text="\$email" />
-    </VBox>
+            <!-- Email -->
+            <VBox fx:id="emailContainer" styleClass="detail-section">
+                <padding>
+                    <Insets bottom="10" />
+                </padding>
+                <Label styleClass="detail-label" text="Email:" />
+                <Label fx:id="email" styleClass="detail-value" text="\$email" />
+            </VBox>
 
-    <!-- Address -->
-    <VBox fx:id="addressContainer" styleClass="detail-section">
-        <padding>
-            <Insets bottom="10" />
-        </padding>
-        <Label styleClass="detail-label" text="Address:" />
-        <Label fx:id="address" styleClass="detail-value" text="\$address" wrapText="true" />
-    </VBox>
+            <!-- Address -->
+            <VBox fx:id="addressContainer" styleClass="detail-section">
+                <padding>
+                    <Insets bottom="10" />
+                </padding>
+                <Label styleClass="detail-label" text="Address:" />
+                <Label fx:id="address" styleClass="detail-value" text="\$address" wrapText="true" />
+            </VBox>
 
-    <!-- Last Contacted -->
-    <VBox fx:id="lastContactedContainer" styleClass="detail-section">
-        <padding>
-            <Insets bottom="10" />
-        </padding>
-        <Label styleClass="detail-label" text="Last Contacted:" />
-        <Label fx:id="lastContacted" styleClass="detail-value" text="\$lastContacted" wrapText="true" />
-    </VBox>
+            <!-- Last Contacted -->
+            <VBox fx:id="lastContactedContainer" styleClass="detail-section">
+                <padding>
+                    <Insets bottom="10" />
+                </padding>
+                <Label styleClass="detail-label" text="Last Contacted:" />
+                <Label fx:id="lastContacted" styleClass="detail-value" text="\$lastContacted" wrapText="true" />
+            </VBox>
 
-    <!-- Last Updated -->
-    <VBox fx:id="lastUpdatedContainer" styleClass="detail-section">
-        <padding>
-            <Insets bottom="10" />
-        </padding>
-        <Label styleClass="detail-label" text="Last Updated:" />
-        <Label fx:id="lastUpdated" styleClass="detail-value" text="\$lastUpdated" wrapText="true" />
-    </VBox>
+            <!-- Last Updated -->
+            <VBox fx:id="lastUpdatedContainer" styleClass="detail-section">
+                <padding>
+                    <Insets bottom="10" />
+                </padding>
+                <Label styleClass="detail-label" text="Last Updated:" />
+                <Label fx:id="lastUpdated" styleClass="detail-value" text="\$lastUpdated" wrapText="true" />
+            </VBox>
 
-    <!-- Notes -->
-    <VBox fx:id="notesContainer" styleClass="detail-section" VBox.vgrow="ALWAYS">
-        <padding>
-            <Insets bottom="10" />
-        </padding>
-        <Label styleClass="detail-label" text="Notes:" />
-        <ScrollPane fx:id="notesScrollPane" fitToWidth="true" VBox.vgrow="ALWAYS">
-            <content>
-            </content>
-        </ScrollPane>
-    </VBox>
+            <!-- Notes -->
+            <VBox fx:id="notesContainer" styleClass="detail-section" VBox.vgrow="ALWAYS">
+                <padding>
+                    <Insets bottom="10" />
+                </padding>
+                <Label styleClass="detail-label" text="Notes:" />
+                    <VBox>
+                        <VBox fx:id="notes" styleClass="detail-value"/>
+                    </VBox>
+            </VBox>
+        </VBox>
+    </ScrollPane>
 </VBox>

--- a/src/main/resources/view/ContactListCard.fxml
+++ b/src/main/resources/view/ContactListCard.fxml
@@ -2,6 +2,7 @@
 
 <?import javafx.geometry.Insets?>
 <?import javafx.scene.control.Label?>
+<?import javafx.scene.control.ScrollPane?>
 <?import javafx.scene.layout.ColumnConstraints?>
 <?import javafx.scene.layout.FlowPane?>
 <?import javafx.scene.layout.GridPane?>
@@ -53,6 +54,10 @@
                 <padding>
                     <Insets bottom="5.0" left="15.0" right="5.0" top="5.0" />
                 </padding>
+                <ScrollPane fx:id="notesScrollPane" fitToWidth="true" minHeight="0.0" styleClass="cell_small_label, notes-cell-background" VBox.vgrow="SOMETIMES">
+                    <content>
+                    </content>
+                </ScrollPane>
             </VBox>
         </VBox>
         <rowConstraints>

--- a/src/main/resources/view/MainWindow.css
+++ b/src/main/resources/view/MainWindow.css
@@ -90,6 +90,19 @@
     -fx-background-color: -note-cell-fill;
 }
 
+.notes-cell-background .scroll-pane {
+    -fx-background-color: transparent;
+}
+
+.notes-cell-background .scroll-pane .viewport {
+    -fx-background-color: transparent;
+}
+
+.notes-cell-background .scroll-pane .scroll-bar {
+    -fx-background-color: transparent;
+    -fx-background-insets: 3;
+}
+
 .stack-pane {
     -fx-background-color: -main-background-color;
 }

--- a/src/main/resources/view/MainWindow.css
+++ b/src/main/resources/view/MainWindow.css
@@ -257,6 +257,13 @@
     -fx-text-fill: -detail-font-color;
 }
 
+.contact-detail-panel .note-index-label {
+    -fx-font-family: "Segoe UI Semibold";
+    -fx-font-size: 14px;
+    -fx-text-fill: -detail-font-color;
+    -fx-padding: 3 0 0 0;
+}
+
 .detail-text-flow {
     -fx-font-family: "Segoe UI";
     -fx-font-size: 14px;


### PR DESCRIPTION
Resolves #330 
Resolves #341 
Resolves #349
## Changes
- Make notes section scrollable in ContactCard
  - Justification:
    - To resolve #341 and #349
    - I don't know how to implement the ellipses thing with Textflow, so this is easier.
    - This does not make the Contact Detail Panel redundant however due to the following change
- Add indexes to notes section in Contact Detail Panel
  - Resolves #330
- Make entirety of details in Contact Detail Panel scrollable
  - Makes the scrollbar easier to use