### PR TITLE
docs: Add lc/ prefix to find command documentation

### DIFF
--- a/docs/user-guide/find-contacts.md
+++ b/docs/user-guide/find-contacts.md
@@ -2,7 +2,7 @@
 
 Finds contacts whose fields match the specified search criteria.
 
-Format: `find [KEYWORD]… [n/NAME] [p/PHONE] [e/EMAIL] [a/ADDRESS] [t/TAG]…`
+Format: `find [KEYWORD]… [n/NAME] [p/PHONE] [e/EMAIL] [a/ADDRESS] [lc/LAST_CONTACTED] [t/TAG]…`
 or: `find @INDEX` to find contacts associated with the contact at INDEX
 
 * The search is case-insensitive. e.g. `hans` will match `Hans`.
@@ -11,7 +11,7 @@ or: `find @INDEX` to find contacts associated with the contact at INDEX
   * Example: Given contact "Alex Yeoh" with note "to meet _on_ Jun 19, 2026"
     * `find Jun` will display contact "Alex Yeoh"
     * `find June` **will not** display contact "Alex Yeoh"
-* Prefixed searches (`n/`, `p/`, `e/`, `a/`) filter by the specified field using partial matching.
+* Prefixed searches (`n/`, `p/`, `e/`, `a/`, `lc/`) filter by the specified field using partial matching.
 * `t/TAG` filters by tag using **exact** matching (e.g. `t/friend` will not match a tag named `friends`).
 * All search conditions are combined with **AND** logic — only contacts satisfying **every** condition are returned.
 * At least one search condition must be provided.

--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -2,6 +2,7 @@ package seedu.address.logic.commands;
 
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_LAST_CONTACTED;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
@@ -19,6 +20,7 @@ public abstract class FindCommand extends Command {
             + "[" + PREFIX_PHONE + "PHONE_KEYWORDS] "
             + "[" + PREFIX_EMAIL + "EMAIL_KEYWORDS] "
             + "[" + PREFIX_ADDRESS + "ADDRESS_KEYWORDS] "
+            + "[" + PREFIX_LAST_CONTACTED + "LAST_CONTACTED_KEYWORDS] "
             + "[" + PREFIX_TAG + "TAG]...\n"
             + "Or: " + COMMAND_WORD + " @INDEX to find contacts associated with the contact at INDEX\n"
             + "Examples: " + COMMAND_WORD + " "


### PR DESCRIPTION
The find command parser supports lc/ (last contacted) filtering but this was not documented in the find-contacts page or the help window MESSAGE_USAGE. Added lc/LAST_CONTACTED to the format line and description.

Fixes #374