### PR TITLE
docs: Fix UC2 extension step number from 1a to 2a

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -441,8 +441,8 @@ Priorities: High (must have) - `* * *`, Medium (nice to have) - `* *`, Low (unli
 
 **Extensions**
 
-* 1a. The new contact is invalid
-  * 1a1. B2B4U shows an error message
+* 2a. The new contact is invalid
+  * 2a1. B2B4U shows an error message
 
     Use case ends.
 


### PR DESCRIPTION
Step 1 is the user's request and step 2 is where B2B4U saves the contact. Validation happens at step 2, so the extension for invalid input should be labelled 2a, not 1a.

Fixes #347