### PR TITLE
fix: Fix HelpWindow size issues

### DIFF
--- a/src/main/resources/view/HelpWindow.fxml
+++ b/src/main/resources/view/HelpWindow.fxml
@@ -9,7 +9,7 @@
 <?import javafx.scene.layout.VBox?>
 <?import javafx.stage.Stage?>
 
-<fx:root resizable="true" title="Help" type="javafx.stage.Stage" minWidth="600" minHeight="200" xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1">
+<fx:root resizable="false" title="Help" type="javafx.stage.Stage" xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1">
   <icons>
     <Image url="@/images/help_icon.png" />
   </icons>


### PR DESCRIPTION
Resolves #365.

### Changes:
- Make HelpWindow no longer resizable by user, as such functionality is unnecessary and can lead to aforementioned cropping issue. If the user finds the window to be blocking their view, it can be minimised/closed anyway.
- Remove HelpWindow minimum size restrictions as it may be larger than what certain help messages need.