### PR TITLE
Edit undo and redo UG

### DIFF
--- a/docs/user-guide/redo-command.md
+++ b/docs/user-guide/redo-command.md
@@ -5,8 +5,8 @@ Reverses the effect of an `undo` command, effectively re-applying the previously
 Format: `redo`
 
 * Only applicable after an `undo` command has been executed.
-* Commands that do not modify data (`help`, `view`, `close view`, `list`, `find`, `undo`, `redo`, `exit`) are ignored by redo.
-* Displays the feedback of the redone command.
+* Restores the application state to the state prior to the previous `undo` command, as if said `undo` command was never executed at all.
+* Displays the feedback of the redone command after successful execution.
 
 Examples:
 * `delete 1` then `undo` then `redo` re-deletes the 1st contact.

--- a/docs/user-guide/redo-command.md
+++ b/docs/user-guide/redo-command.md
@@ -1,6 +1,6 @@
 # Redoing a command: `redo`
 
-Reverses the effect of an `undo` command, effectively re-applying the previously undone action.
+Reverses the effect of an [`undo` command]({{ baseUrl }}/user-guide/undo-command.html), effectively re-applying the previously undone action.
 
 Format: `redo`
 

--- a/docs/user-guide/undo-command.md
+++ b/docs/user-guide/undo-command.md
@@ -4,9 +4,12 @@ Reverts the last executed command that modified data.
 
 Format: `undo`
 
-* Only commands that modify data can be undone (e.g. `add`, `edit`, `delete`, `note`, `clear`, `sort`).
-* Commands that do not modify data (`help`, `view`, `close view`, `list`, `find`, `undo`, `redo`, `exit`) are ignored by undo.
-* Displays the feedback of the undone command.
+* Only the following commands can be undone:
+  * Commands that modify contact list data: `add`, `edit`, `delete`, `note`, `clear`
+  * Commands that change the filter/sort patterns: `list`, `find`, `sort`
+  * Commands that modify application settings: `file`, `theme`
+* Commands do not fall in the above categories (`help`, `view`, `close view`, `undo`, `redo`, `exit`) are ignored by undo.
+* Displays the feedback of the undone command after execution.
 
 Examples:
 * `delete 1` followed by `undo` restores the deleted contact.

--- a/docs/user-guide/undo-command.md
+++ b/docs/user-guide/undo-command.md
@@ -8,7 +8,7 @@ Format: `undo`
   * Commands that modify contact list data: `add`, `edit`, `delete`, `note`, `clear`
   * Commands that change the filter/sort patterns: `list`, `find`, `sort`
   * Commands that modify application settings: `file`, `theme`
-* Commands do not fall in the above categories (`help`, `view`, `close view`, `undo`, `redo`, `exit`) are ignored by undo.
+* Commands that do not fall in the above categories (`help`, `view`, `close view`, `undo`, `redo`, `exit`) are ignored by undo.
 * Displays the feedback of the undone command after execution.
 
 Examples:


### PR DESCRIPTION
Resolves #367

- Change Undo page in UG to correctly reflect commands it can undo and commands it ignores.
- Change Redo page to rely on `undo` function more for its explanation.