### PR TITLE
Include sort criteria in sort command feedback message

### DIFF
--- a/src/main/java/seedu/address/logic/commands/SortCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SortCommand.java
@@ -23,7 +23,7 @@ public class SortCommand extends Command {
 
     public static final String ASCENDING_KEYWORD = "asc";
     public static final String DESCENDING_KEYWORD = "desc";
-    public static final String MESSAGE_SUCCESS = "Sorted %d contacts.";
+    public static final String MESSAGE_SUCCESS = "Sorted %d contacts by %s.";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Sorts contacts by the given fields "
         + "and displays them as a list with index numbers.\n"
@@ -62,7 +62,8 @@ public class SortCommand extends Command {
 
         model.sortDisplayedContactList(comparator);
 
-        String feedback = String.format(MESSAGE_SUCCESS, model.getDisplayedContactList().size());
+        String feedback = String.format(MESSAGE_SUCCESS, model.getDisplayedContactList().size(),
+                comparator.getDescription());
         model.saveSnapshot(feedback);
         return new CommandResult(feedback);
     }

--- a/src/main/java/seedu/address/model/contact/ContactComparator.java
+++ b/src/main/java/seedu/address/model/contact/ContactComparator.java
@@ -5,6 +5,7 @@ import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
+import java.util.stream.Collectors;
 
 import seedu.address.commons.util.ToStringBuilder;
 
@@ -97,6 +98,25 @@ public abstract class ContactComparator implements Comparator<Contact> {
         }
 
         return this.comparators.equals(otherObj.comparators);
+    }
+
+    /**
+     * Returns a user-friendly description of the sort criteria.
+     */
+    public String getDescription() {
+        if (comparators.isEmpty()) {
+            return "default order";
+        }
+        return comparators.stream()
+            .map(ContactComparator::getSingleDescription)
+            .collect(Collectors.joining(", "));
+    }
+
+    /**
+     * Returns the description for a single comparator.
+     */
+    protected String getSingleDescription() {
+        return "default order";
     }
 
     @Override

--- a/src/main/java/seedu/address/model/contact/ContactFieldComparator.java
+++ b/src/main/java/seedu/address/model/contact/ContactFieldComparator.java
@@ -105,6 +105,12 @@ public class ContactFieldComparator extends ContactComparator {
     }
 
     @Override
+    protected String getSingleDescription() {
+        return field.name().toLowerCase().replace("_", " ")
+            + " (" + order.name().toLowerCase() + ")";
+    }
+
+    @Override
     public String toString() {
         return new ToStringBuilder(this).add("field", field).add("order", order).toString();
     }

--- a/src/main/java/seedu/address/model/contact/ContactTagComparator.java
+++ b/src/main/java/seedu/address/model/contact/ContactTagComparator.java
@@ -97,6 +97,11 @@ public final class ContactTagComparator extends ContactComparator {
     }
 
     @Override
+    protected String getSingleDescription() {
+        return "tag '" + tag + "' (" + order.name().toLowerCase() + ")";
+    }
+
+    @Override
     public String toString() {
         return new ToStringBuilder(this)
             .add("tag", tag)

--- a/src/test/java/seedu/address/model/contact/ContactComparatorTest.java
+++ b/src/test/java/seedu/address/model/contact/ContactComparatorTest.java
@@ -75,6 +75,22 @@ public class ContactComparatorTest {
     }
 
     @Test
+    public void getDescription_identity_returnsDefaultOrder() {
+        assertEquals("default order", identityComparator.getDescription());
+    }
+
+    @Test
+    public void getDescription_singleField_returnsFieldAndOrder() {
+        assertEquals("name (ascending)", comparatorA1.getDescription());
+    }
+
+    @Test
+    public void getDescription_multipleFields_returnsCommaSeparated() {
+        assertEquals("last contacted (descending), tag 'friends' (descending), phone (ascending)",
+                comparatorB1.getDescription());
+    }
+
+    @Test
     public void hasAllComparators() {
         for (Field field : Field.values()) {
             for (Order order : Order.values()) {


### PR DESCRIPTION
The sort command previously showed 'Sorted X contacts.' without specifying the criteria used. Add `getDescription()` to comparator hierarchy so the message now shows the criteria, e.g. 'Sorted 11 contacts by name (ascending).'

Fixes #371