### PR TITLE
Clarify phone error message for country code numbers

### DIFF
--- a/src/main/java/seedu/address/model/contact/Phone.java
+++ b/src/main/java/seedu/address/model/contact/Phone.java
@@ -11,7 +11,9 @@ public class Phone implements Comparable<Phone> {
 
 
     public static final String MESSAGE_CONSTRAINTS =
-            "Phone numbers should only contain '+' and digits, and it should be 5-15 digits long";
+            "Phone numbers should only contain '+' and digits. "
+            + "Without a country code, they should be 5-14 digits long. "
+            + "With a country code (starting with '+'), they should be 8-15 digits long";
     public static final String VALIDATION_REGEX = "^(\\+\\d{8,15}|\\d{5,14})$";
     public final String value;
 


### PR DESCRIPTION
The error message for invalid phone numbers said '5-15 digits long' which did not distinguish between numbers with and without a country code prefix (`+`). Numbers starting with `+` require 8-15 digits, while others require 5-14 digits. Updated the message to clarify both constraints.

This also resolves the mismatch where the old message said 15 digits were allowed without a country code, but the regex only accepts up to 14 digits without `+`.

Fixes #344
Fixes #329