### PR TITLE
Remove 'Image to be added' placeholder in view files section

### DIFF
--- a/docs/user-guide/view.md
+++ b/docs/user-guide/view.md
@@ -18,6 +18,4 @@ Example:
 
 Displays all the B2B4U contact list files in the data subfolder in a side panel, each with the number of contacts they contain.
 
-Image to be added
-
 Format: `view files`


### PR DESCRIPTION
The 'Viewing available files' section of the User Guide had a placeholder text 'Image to be added' that was displayed in the rendered documentation. Remove it to clean up the User Guide.

Fixes #351