### PR TITLE
Document duplicate contact detection criteria in UG

### DIFF
--- a/docs/user-guide/add-contact.md
+++ b/docs/user-guide/add-contact.md
@@ -22,6 +22,16 @@ Examples:
 
 ![add contact]({{ baseUrl }}/images/addContact.png)
 
+### Duplicate contacts
+
+A contact is considered a **duplicate** of an existing contact if all of the following match:
+
+- Same name
+- Same phone number
+- Same email address
+
+If you try to add a duplicate contact, B2B4U will reject the command with the message: "This contact already exists in the address book".
+
 ### Similar contacts
 After a successful `add` command, the contact list will be reset to display every contact in the default sort order, then if there are similar contacts in the list, the contact list will be displayed to display the similar contacts.
 

--- a/docs/user-guide/add-contact.md
+++ b/docs/user-guide/add-contact.md
@@ -24,11 +24,11 @@ Examples:
 
 ### Duplicate contacts
 
-A contact is considered a **duplicate** of an existing contact if all of the following match:
+A contact is considered a **duplicate** of an existing contact if all of the following criteria hold:
 
-- Same name
-- Same phone number
-- Same email address
+- Both contacts have the exact same name
+- Both contacts have the exact same phone number
+- Both contacts have the exact same email address
 
 If you try to add a duplicate contact, B2B4U will reject the command with the message: "This contact already exists in the address book".
 


### PR DESCRIPTION
The User Guide explained when contacts are 'similar' (any of name/phone/email matches) but did not explain when contacts are considered duplicates and rejected. Added a section documenting that a contact is a duplicate when name, phone, and email all match an existing contact.

Fixes #377