### PR TITLE
Define what 'due' means in reminders documentation

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -189,7 +189,7 @@ Notes support **contact references** using the `@INDEX` syntax, which creates a 
 
 #### Reminders
 
-Any note with a scheduled time (set using `on/TIME`) becomes a reminder. Contacts with active reminders gain a `Reminder` tag, which turns red when the reminder is due within **7 days**. During this window, a pop-up notification will also appear each time you launch B2B4U.
+Any note with a scheduled time (set using `on/TIME`) becomes a reminder. Contacts with active reminders gain a `Reminder` tag, which turns red when the reminder is due within **7 days**. A reminder is considered "due" when its scheduled date has not yet passed and falls within the next 7 days from today. During this window, a pop-up notification will also appear each time you launch B2B4U.
 
 ![reminder]({{ baseUrl }}/images/reminder.png)
 

--- a/docs/user-guide/notes.md
+++ b/docs/user-guide/notes.md
@@ -79,7 +79,8 @@ Contacts with a reminder will gain a special `Reminder` tag and automatically be
 
 ![Reminder]({{ baseUrl }}/images/notes-reminder.png)
 
-Users will be notified that the reminder of a contact is due within 7 days in the following ways:
+Users will be notified that the reminder of a contact is due within 7 days in the following ways.
+A reminder is considered "due" when its scheduled date has not yet passed and falls within the next 7 days from today:
 - The `Reminder` tag of the contact will turn reddish
 - The contact will be placed at the very top of the contact list, above other contacts without a due reminder
 - A reminder window will pop-up during startup


### PR DESCRIPTION
The reminders section stated the Reminder tag turns red when a reminder is 'due within 7 days' but never defined 'due'. Clarified that a reminder is considered due when its scheduled date has not yet passed and falls within the next 7 days from today.

Fixes #342