### PR TITLE
fix: Change TimePoint comparison

### DIFF
--- a/src/main/java/seedu/address/commons/core/timepoint/DateTimePoint.java
+++ b/src/main/java/seedu/address/commons/core/timepoint/DateTimePoint.java
@@ -33,7 +33,8 @@ public class DateTimePoint extends TimePoint<LocalDate> {
             return this.getTime().isAfter(((DateTimePoint) other).getTime());
         }
         if (other instanceof DateTimeTimePoint) {
-            return this.getTime().isAfter(((DateTimeTimePoint) other).getTime().toLocalDate());
+            return this.getTime().isAfter(((DateTimeTimePoint) other).getTime().toLocalDate())
+                    || this.isSameDayAs(other);
         }
         return false;
     }
@@ -47,7 +48,8 @@ public class DateTimePoint extends TimePoint<LocalDate> {
             return this.getTime().isBefore(((DateTimePoint) other).getTime());
         }
         if (other instanceof DateTimeTimePoint) {
-            return this.getTime().isBefore(((DateTimeTimePoint) other).getTime().toLocalDate());
+            return this.getTime().isBefore(((DateTimeTimePoint) other).getTime().toLocalDate())
+                    || this.isSameDayAs(other);
         }
         return false;
     }

--- a/src/main/java/seedu/address/commons/core/timepoint/DateTimeTimePoint.java
+++ b/src/main/java/seedu/address/commons/core/timepoint/DateTimeTimePoint.java
@@ -32,7 +32,7 @@ public class DateTimeTimePoint extends TimePoint<LocalDateTime> {
             return false;
         }
         if (other instanceof DateTimePoint) {
-            return this.getTime().toLocalDate().isAfter(((DateTimePoint) other).getTime());
+            return this.getTime().toLocalDate().isAfter(((DateTimePoint) other).getTime()) || this.isSameDayAs(other);
         }
         if (other instanceof DateTimeTimePoint) {
             return this.getTime().isAfter(((DateTimeTimePoint) other).getTime());
@@ -46,7 +46,7 @@ public class DateTimeTimePoint extends TimePoint<LocalDateTime> {
             return false;
         }
         if (other instanceof DateTimePoint) {
-            return this.getTime().toLocalDate().isBefore(((DateTimePoint) other).getTime());
+            return this.getTime().toLocalDate().isBefore(((DateTimePoint) other).getTime()) || this.isSameDayAs(other);
         }
         if (other instanceof DateTimeTimePoint) {
             return this.getTime().isBefore(((DateTimeTimePoint) other).getTime());

--- a/src/test/java/seedu/address/commons/core/timepoint/TimePointTest.java
+++ b/src/test/java/seedu/address/commons/core/timepoint/TimePointTest.java
@@ -87,6 +87,7 @@ public class TimePointTest {
         assertFalse(stringDate.isAfter(null));
 
         //Date formatted TimePoint checks only for the day
+        assertTrue(date1.isAfter(dateTime1));
         assertTrue(date2.isAfter(date1));
         assertTrue(date2.isAfter(TimePoint.of(LocalDate.of(2024, 5, 10))));
         assertTrue(date2.isAfter(dateTime1));
@@ -96,7 +97,6 @@ public class TimePointTest {
         assertFalse(date1.isAfter(date1));
         assertFalse(date1.isAfter(stringDate));
         assertFalse(date2.isAfter(stringDate));
-        assertFalse(date1.isAfter(dateTime1));
         assertFalse(date1.isAfter(dateTime2));
         assertFalse(date2.isAfter(null));
 
@@ -106,9 +106,9 @@ public class TimePointTest {
         assertTrue(dateTimeDiffTime.isAfter(dateTime1));
         assertTrue(dateTime2.isAfter(dateTimeDiffTime));
         assertTrue(dateTime2.isAfter(date1));
+        assertTrue(dateTime1.isAfter(date1));
 
         //DateTime formatted TimePoint returns false when given same time, later times or null
-        assertFalse(dateTime1.isAfter(date1));
         assertFalse(dateTime1.isAfter(dateTime1));
         assertFalse(dateTime1.isAfter(date2));
         assertFalse(dateTime1.isAfter(dateTime2));
@@ -137,15 +137,15 @@ public class TimePointTest {
 
         //Date formatted TimePoint checks only for the day
         assertTrue(date1.isBefore(date2));
+        assertTrue(date1.isBefore(dateTime));
         assertTrue(date1.isBefore(TimePoint.of(LocalDate.of(2024, 5, 12))));
+        assertTrue(date1.isBefore(dateTimeDiffTime));
         assertTrue(date1.isBefore(dateTimeDiffDay));
 
         //Date formatted TimePoint returns false when given same day, later dates or null
         assertFalse(date1.isBefore(date1));
         assertFalse(date1.isBefore(stringDate));
         assertFalse(date2.isBefore(stringDate));
-        assertFalse(date1.isBefore(dateTime));
-        assertFalse(date1.isBefore(dateTimeDiffTime));
         assertFalse(date2.isBefore(null));
 
         //DateTime formatted TimePoint checks for both date and time if possible, if given only a date,
@@ -154,9 +154,9 @@ public class TimePointTest {
         assertTrue(dateTimeDiffTime.isBefore(dateTimeDiffDay));
         assertTrue(dateTime.isBefore(date2));
         assertTrue(dateTimeDiffTime.isBefore(date2));
+        assertTrue(dateTime.isBefore(date1));
 
         //DateTime formatted TimePoint returns false when given same time, later times or null
-        assertFalse(dateTime.isBefore(date1));
         assertFalse(dateTime.isBefore(dateTime));
         assertFalse(dateTimeDiffTime.isBefore(dateTime));
         assertFalse(dateTimeDiffDay.isBefore(dateTime));

--- a/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
@@ -154,12 +154,12 @@ public class FindCommandParserTest {
     @Test
     public void parse_findLastContactedBeforeDate_test() throws ParseException {
         FindCommand command = parser.parse(" " + PREFIX_LAST_CONTACTED + PREFIX_BEFORE + "22/02/2026");
-        String expectedMessage = "Found 1 contacts matching 'lc/before/22/02/2026'";
+        String expectedMessage = "Found 3 contacts matching 'lc/before/22/02/2026'";
         Predicate<Contact> predicate =
                 contact -> contact.lastContactedIsBefore(TimePoint.of(LocalDate.of(2026, 2, 22)));
         expectedModel.filterDisplayedContactList(predicate);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
-        assertEquals(Arrays.asList(DANIEL), model.getDisplayedContactList());
+        assertEquals(Arrays.asList(GEORGE, FIONA, DANIEL), model.getDisplayedContactList());
     }
 
     @Test
@@ -176,12 +176,12 @@ public class FindCommandParserTest {
     @Test
     public void parse_findLastContactedAfterDate_test() throws ParseException {
         FindCommand command = parser.parse(" " + PREFIX_LAST_CONTACTED + PREFIX_AFTER + "22/02/2026");
-        String expectedMessage = "Found 1 contacts matching 'lc/after/22/02/2026'";
+        String expectedMessage = "Found 3 contacts matching 'lc/after/22/02/2026'";
         Predicate<Contact> predicate =
                 contact -> contact.lastContactedIsAfter(TimePoint.of(LocalDate.of(2026, 2, 22)));
         expectedModel.filterDisplayedContactList(predicate);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
-        assertEquals(Arrays.asList(CARL), model.getDisplayedContactList());
+        assertEquals(Arrays.asList(CARL, GEORGE, FIONA), model.getDisplayedContactList());
     }
 
     @Test


### PR DESCRIPTION
Resolves #332.

**Changes: ** A `DateTimePoint` with the same day as a `DateTimeTimePoint` will return `true` for `isBefore` and `isAfter` comparisons if both are on the same day, with the idea that a `DateTimePoint` encompasses every time in the day and can return `true` so long as it contains a "time" that can return `true` for the `DateTimeTimePoint`. Thus reminders that are set for today will remain at a "due" state throughout the day, while reminders set for a specific time will only remain at a "due" state as long as the system is before its specific time.