### PR TITLE
fix: allow "reminder" to be searchable in `find` command

### DIFF
--- a/src/main/java/seedu/address/model/contact/Contact.java
+++ b/src/main/java/seedu/address/model/contact/Contact.java
@@ -151,8 +151,8 @@ public class Contact {
                 || containsInAddress(string)
                 || containsInNotes(string)
                 || containsInTags(string)
-                || (hasReminders() &&
-                        (string.equalsIgnoreCase("reminder") || string.equalsIgnoreCase("reminders")));
+                || (hasReminders()
+                        && (string.equalsIgnoreCase("reminder") || string.equalsIgnoreCase("reminders")));
     }
 
     /**

--- a/src/main/java/seedu/address/model/contact/Contact.java
+++ b/src/main/java/seedu/address/model/contact/Contact.java
@@ -150,7 +150,9 @@ public class Contact {
                 || containsInEmail(string)
                 || containsInAddress(string)
                 || containsInNotes(string)
-                || containsInTags(string);
+                || containsInTags(string)
+                || (hasReminders() &&
+                        (string.equalsIgnoreCase("reminder") || string.equalsIgnoreCase("reminders")));
     }
 
     /**
@@ -293,6 +295,13 @@ public class Contact {
      */
     public boolean hasLastContacted() {
         return lastContacted.isPresent();
+    }
+
+    /**
+     * Checks if this contact contain reminders.
+     */
+    public boolean hasReminders() {
+        return notes.stream().anyMatch(Note::isReminder);
     }
 
     /**

--- a/src/main/java/seedu/address/ui/ContactCard.java
+++ b/src/main/java/seedu/address/ui/ContactCard.java
@@ -36,6 +36,8 @@ public class ContactCard extends UiPart<Region> {
     @FXML
     private Label name;
     @FXML
+    private FlowPane info;
+    @FXML
     private Label id;
     @FXML
     private Label phone;
@@ -89,28 +91,32 @@ public class ContactCard extends UiPart<Region> {
         } else {
             UiUtil.hide(notesContainer);
         }
-        if (!(contact.getTags().isEmpty()
-                && contact.getReminders().isEmpty()
-                && contact.getLastContacted().isEmpty())) {
+        
+        // Set up info flow pane
+        if (!(contact.getReminders().isEmpty() && contact.getLastContacted().isEmpty())) {
+            contact.getLastContacted().ifPresent(lc ->  {
+                Label lastContactedLabel = new Label("Last Contacted: " + lc);
+                info.getChildren().add(lastContactedLabel);
+            });
+            if (!contact.getReminders().isEmpty()) {
+                Label reminderLabel = new Label("Reminder");
+                if (contact.hasDueReminders()) {
+                    reminderLabel.getStyleClass().add("warning-label");
+                }
+                info.getChildren().add(reminderLabel);
+            }
+        } else {
+            UiUtil.hide(info);
+        }
+        
+        // Set up tags flow pane
+        if (!contact.getTags().isEmpty()) {
             contact.getTags().stream()
                     .sorted(Comparator.comparing(tag -> tag.name))
                     .forEach(tag -> tags.getChildren().add(
                         tag instanceof RankedTag
                             ? new RankedTagLabel((RankedTag) tag)
                             : new Label(tag.name)));
-
-            if (!contact.getLastContacted().isEmpty()) {
-                Label lastContactedLabel = new Label("Last Contacted: " + contact.getLastContacted().get());
-                tags.getChildren().add(lastContactedLabel);
-            }
-
-            if (!contact.getReminders().isEmpty()) {
-                Label reminderLabel = new Label("Reminder");
-                if (contact.hasDueReminders()) {
-                    reminderLabel.getStyleClass().add("warning-label");
-                }
-                tags.getChildren().add(reminderLabel);
-            }
         } else {
             UiUtil.hide(tags);
         }

--- a/src/main/java/seedu/address/ui/ContactCard.java
+++ b/src/main/java/seedu/address/ui/ContactCard.java
@@ -91,10 +91,10 @@ public class ContactCard extends UiPart<Region> {
         } else {
             UiUtil.hide(notesContainer);
         }
-        
+
         // Set up info flow pane
         if (!(contact.getReminders().isEmpty() && contact.getLastContacted().isEmpty())) {
-            contact.getLastContacted().ifPresent(lc ->  {
+            contact.getLastContacted().ifPresent(lc -> {
                 Label lastContactedLabel = new Label("Last Contacted: " + lc);
                 info.getChildren().add(lastContactedLabel);
             });
@@ -108,7 +108,7 @@ public class ContactCard extends UiPart<Region> {
         } else {
             UiUtil.hide(info);
         }
-        
+
         // Set up tags flow pane
         if (!contact.getTags().isEmpty()) {
             contact.getTags().stream()

--- a/src/main/resources/view/ContactListCard.fxml
+++ b/src/main/resources/view/ContactListCard.fxml
@@ -28,6 +28,11 @@
                             </minWidth>
                         </Label>
                         <Label fx:id="name" styleClass="cell_big_label" text="\$first" />
+                        <FlowPane fx:id="info" translateY="2.0">
+                            <HBox.margin>
+                                <Insets left="5.0" />
+                            </HBox.margin>
+                        </FlowPane>
                         <Pane HBox.hgrow="ALWAYS" />
                         <Label fx:id="lastUpdated" alignment="TOP_RIGHT" minWidth="-Infinity" styleClass="cell_soft_label, italic" text="\$lastUpdated">
                             <padding>

--- a/src/main/resources/view/MainWindow.css
+++ b/src/main/resources/view/MainWindow.css
@@ -217,6 +217,25 @@
     -fx-background-radius: 0;
 }
 
+#info {
+    -fx-hgap: 7;
+    -fx-vgap: 3;
+}
+
+#info .label {
+    -fx-text-fill: -main-font-color;
+    -fx-background-color: -highlight;
+    -fx-padding: 1 3 1 3;
+    -fx-border-radius: 2;
+    -fx-background-radius: 2;
+    -fx-font-size: 11;
+    -fx-font-style: italic;
+}
+
+#info .warning-label {
+    -fx-background-color: -warning;
+}
+
 #tags {
     -fx-hgap: 7;
     -fx-vgap: 3;
@@ -229,10 +248,6 @@
     -fx-border-radius: 2;
     -fx-background-radius: 2;
     -fx-font-size: 11;
-}
-
-#tags .warning-label {
-    -fx-background-color: -warning;
 }
 
 /* Contact Detail Panel Styles */

--- a/src/test/java/seedu/address/model/contact/ContactTest.java
+++ b/src/test/java/seedu/address/model/contact/ContactTest.java
@@ -26,7 +26,7 @@ public class ContactTest {
     private static final Contact JOHN = new ContactBuilder()
             .withName("John Smith").withPhone("94455028").withEmail("john@email.com")
             .withAddress("Block 470, J Street 92").withTags("friends", "contractor")
-            .withNotes("Met in 2024 February.").withLastContacted("22/04/2026").build();
+            .withNotes("Met in 2024 February.", "Meet on/22/04/2024 13:20").withLastContacted("22/04/2026").build();
 
     @Test
     public void asObservableList_modifyList_throwsUnsupportedOperationException() {
@@ -70,6 +70,7 @@ public class ContactTest {
         assertTrue(JOHN.contains("FRIEND"));
         assertTrue(JOHN.contains("February"));
         assertFalse(JOHN.contains("Singapore"));
+        assertTrue(JOHN.contains("reminder"));
     }
 
     @Test

--- a/src/test/java/seedu/address/ui/ContactCardTest.java
+++ b/src/test/java/seedu/address/ui/ContactCardTest.java
@@ -105,8 +105,8 @@ public class ContactCardTest extends GuiUnitTest {
                     .withNotes(dueReminderString)
                     .build(), 3, FXCollections.observableArrayList());
 
-            FlowPane tags = getPrivateField(card, "tags", FlowPane.class);
-            List<Label> labels = tags.getChildren().stream()
+            FlowPane info = getPrivateField(card, "info", FlowPane.class);
+            List<Label> labels = info.getChildren().stream()
                     .filter(node -> node instanceof Label)
                     .map(node -> (Label) node)
                     .collect(Collectors.toList());


### PR DESCRIPTION
Fixes #353.

- Moved "last contacted" and "reminder" labels to the right of name field, and italicize them.

- Added "reminder" and "reminders" as searchable text, where contacts are considered to contain these strings if there is at least one note reminder.
  - Changed `Contact::contains` method.
  - A hacky fix, suggestions for alternatives are welcome.