### PR TITLE
fix: Add padding to special tags

### DIFF
--- a/src/main/resources/view/ContactListCard.fxml
+++ b/src/main/resources/view/ContactListCard.fxml
@@ -27,10 +27,15 @@
                                 <Region fx:constant="USE_PREF_SIZE" />
                             </minWidth>
                         </Label>
-                        <Label fx:id="name" styleClass="cell_big_label" text="\$first" />
+                        <Label fx:id="name" styleClass="cell_big_label" text="\$first">
+                            <minWidth>
+                                <!-- Ensures that the label text is never truncated -->
+                                <Region fx:constant="USE_PREF_SIZE" />
+                            </minWidth>
+                        </Label>
                         <FlowPane fx:id="info" translateY="2.0">
                             <HBox.margin>
-                                <Insets left="5.0" />
+                                <Insets left="5.0" right="5.0"/>
                             </HBox.margin>
                             <padding>
                                 <Insets bottom="6.0" />

--- a/src/main/resources/view/ContactListCard.fxml
+++ b/src/main/resources/view/ContactListCard.fxml
@@ -32,6 +32,9 @@
                             <HBox.margin>
                                 <Insets left="5.0" />
                             </HBox.margin>
+                            <padding>
+                                <Insets bottom="6.0" />
+                            </padding>
                         </FlowPane>
                         <Pane HBox.hgrow="ALWAYS" />
                         <Label fx:id="lastUpdated" alignment="TOP_RIGHT" minWidth="-Infinity" styleClass="cell_soft_label, italic" text="\$lastUpdated">


### PR DESCRIPTION
Resolves #417.
Solution: add bottom padding
Additional change: Fix name to always display full name
<img width="768" height="838" alt="image" src="https://github.com/user-attachments/assets/a52c266d-17b5-47f8-82b9-169e86017162" />
