### PR TITLE
Simplify edit command sequence diagram in DG

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -226,14 +226,13 @@ The edit command supports removing optional fields (phone, email, address, last 
 
 #### Implementation
 
-The following sequence diagram shows how the edit field removal mechanism works when the user executes `edit 1 p/`:
+The following sequence diagram shows the execution of `EditCommand` when the user runs `edit 1 p/`:
 
 <puml src="{{ baseUrl }}/diagrams/EditSequenceDiagram.puml" alt="EditSequenceDiagram" />
 
-1. `EditCommandParser` detects the empty value for the `p/` prefix and sets `clearPhone = true` in the `EditContactDescriptor`.
-2. `EditCommand#createEditedContact()` checks the clear flag — if `clearPhone` is true, `updatedPhone` is set to `Optional.empty()`.
-3. Before applying the edit, the command validates that the resulting contact retains at least a phone number or email address.
-4. The updated contact is saved to the model.
+1. `EditCommand#createEditedContact()` applies changes from the `EditContactDescriptor` to the target contact. Clear flags (e.g. `clearPhone`) cause the corresponding optional field to be removed.
+2. `EditCommand#validate()` checks that the edited contact retains at least a phone number or email address.
+3. The updated contact is saved to the model via `setContact()` and a snapshot is saved for undo support.
 
 #### Design considerations
 

--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -226,13 +226,12 @@ The edit command supports removing optional fields (phone, email, address, last 
 
 #### Implementation
 
-The following sequence diagram shows the execution of `EditCommand` when the user runs `edit 1 p/`:
+The following sequence diagram shows how the edit command processes `edit 1 p/`:
 
 <puml src="{{ baseUrl }}/diagrams/EditSequenceDiagram.puml" alt="EditSequenceDiagram" />
 
-1. `EditCommand#createEditedContact()` applies changes from the `EditContactDescriptor` to the target contact. Clear flags (e.g. `clearPhone`) cause the corresponding optional field to be removed.
-2. `EditCommand#validate()` checks that the edited contact retains at least a phone number or email address.
-3. The updated contact is saved to the model via `setContact()` and a snapshot is saved for undo support.
+1. `EditCommandParser` detects the empty `p/` prefix and sets `clearPhone = true` in the `EditContactDescriptor`.
+2. During execution, `EditCommand` validates the edited contact and saves it to the model.
 
 #### Design considerations
 

--- a/docs/diagrams/EditSequenceDiagram.puml
+++ b/docs/diagrams/EditSequenceDiagram.puml
@@ -4,6 +4,7 @@ skinparam ArrowFontStyle plain
 
 box Logic LOGIC_COLOR_T1
 participant "e:EditCommand" as EditCommand LOGIC_COLOR
+participant "r:CommandResult" as CommandResult LOGIC_COLOR
 end box
 
 box Model MODEL_COLOR_T1
@@ -48,7 +49,7 @@ activate Model
 Model --> EditCommand
 deactivate Model
 
-create "r:CommandResult" as CommandResult LOGIC_COLOR
+create CommandResult
 EditCommand -> CommandResult
 activate CommandResult
 

--- a/docs/diagrams/EditSequenceDiagram.puml
+++ b/docs/diagrams/EditSequenceDiagram.puml
@@ -3,6 +3,9 @@
 skinparam ArrowFontStyle plain
 
 box Logic LOGIC_COLOR_T1
+participant ":LogicManager" as LogicManager LOGIC_COLOR
+participant ":AddressBookParser" as AddressBookParser LOGIC_COLOR
+participant ":EditCommandParser" as EditCommandParser LOGIC_COLOR
 participant "e:EditCommand" as EditCommand LOGIC_COLOR
 participant "r:CommandResult" as CommandResult LOGIC_COLOR
 end box
@@ -11,31 +14,52 @@ box Model MODEL_COLOR_T1
 participant "m:Model" as Model MODEL_COLOR
 end box
 
-[-> EditCommand : execute(m)
-activate EditCommand
+[-> LogicManager : execute("edit 1 p/")
+activate LogicManager
 
-EditCommand -> EditCommand : createEditedContact()
-activate EditCommand
+LogicManager -> AddressBookParser : parseCommand("edit 1 p/")
+activate AddressBookParser
 
-note right of EditCommand
-  Applies changes from EditContactDescriptor
-  to the target contact. Clear flags (e.g.
-  clearPhone) remove optional fields.
+create EditCommandParser
+AddressBookParser -> EditCommandParser
+activate EditCommandParser
+
+EditCommandParser --> AddressBookParser
+deactivate EditCommandParser
+
+AddressBookParser -> EditCommandParser : parse("1 p/")
+activate EditCommandParser
+
+note right of EditCommandParser
+  Detects empty "p/" prefix,
+  sets clearPhone = true in
+  EditContactDescriptor
 end note
 
-EditCommand --> EditCommand : editedContact
-deactivate EditCommand
-
-EditCommand -> EditCommand : validate(editedContact)
+create EditCommand
+EditCommandParser -> EditCommand
 activate EditCommand
 
-note right of EditCommand
-  Checks that the edited contact
-  retains at least a phone or email
-end note
-
-EditCommand --> EditCommand
+EditCommand --> EditCommandParser :
 deactivate EditCommand
+
+EditCommandParser --> AddressBookParser : e
+deactivate EditCommandParser
+'Hidden arrow to position the destroy marker below the end of the activation bar.
+EditCommandParser -[hidden]-> AddressBookParser
+destroy EditCommandParser
+
+AddressBookParser --> LogicManager : e
+deactivate AddressBookParser
+
+LogicManager -> EditCommand : execute(m)
+activate EditCommand
+
+EditCommand -> Model : validate(editedContact)
+activate Model
+
+Model --> EditCommand
+deactivate Model
 
 EditCommand -> Model : setContact(contactToEdit, editedContact)
 activate Model
@@ -56,7 +80,9 @@ activate CommandResult
 CommandResult --> EditCommand
 deactivate CommandResult
 
-[<-- EditCommand : r
+EditCommand --> LogicManager : r
 deactivate EditCommand
 
+[<--LogicManager
+deactivate LogicManager
 @enduml

--- a/docs/diagrams/EditSequenceDiagram.puml
+++ b/docs/diagrams/EditSequenceDiagram.puml
@@ -56,7 +56,7 @@ activate CommandResult
 CommandResult --> EditCommand
 deactivate CommandResult
 
-EditCommand --> [: r
+[<-- EditCommand : r
 deactivate EditCommand
 
 @enduml

--- a/docs/diagrams/EditSequenceDiagram.puml
+++ b/docs/diagrams/EditSequenceDiagram.puml
@@ -3,64 +3,23 @@
 skinparam ArrowFontStyle plain
 
 box Logic LOGIC_COLOR_T1
-participant ":LogicManager" as LogicManager LOGIC_COLOR
-participant ":AddressBookParser" as AddressBookParser LOGIC_COLOR
-participant ":EditCommandParser" as EditCommandParser LOGIC_COLOR
 participant "e:EditCommand" as EditCommand LOGIC_COLOR
-participant "r:CommandResult" as CommandResult LOGIC_COLOR
 end box
 
 box Model MODEL_COLOR_T1
 participant "m:Model" as Model MODEL_COLOR
 end box
 
-[-> LogicManager : execute("edit 1 p/")
-activate LogicManager
-
-LogicManager -> AddressBookParser : parseCommand("edit 1 p/")
-activate AddressBookParser
-
-create EditCommandParser
-AddressBookParser -> EditCommandParser
-activate EditCommandParser
-
-EditCommandParser --> AddressBookParser
-deactivate EditCommandParser
-
-AddressBookParser -> EditCommandParser : parse("1 p/")
-activate EditCommandParser
-
-note right of EditCommandParser
-  Detects empty "p/" prefix,
-  sets clearPhone = true in
-  EditContactDescriptor
-end note
-
-create EditCommand
-EditCommandParser -> EditCommand
-activate EditCommand
-
-EditCommand --> EditCommandParser :
-deactivate EditCommand
-
-EditCommandParser --> AddressBookParser : e
-deactivate EditCommandParser
-'Hidden arrow to position the destroy marker below the end of the activation bar.
-EditCommandParser -[hidden]-> AddressBookParser
-destroy EditCommandParser
-
-AddressBookParser --> LogicManager : e
-deactivate AddressBookParser
-
-LogicManager -> EditCommand : execute(m)
+[-> EditCommand : execute(m)
 activate EditCommand
 
 EditCommand -> EditCommand : createEditedContact()
 activate EditCommand
 
 note right of EditCommand
-  clearPhone is true,
-  so updatedPhone = Optional.empty()
+  Applies changes from EditContactDescriptor
+  to the target contact. Clear flags (e.g.
+  clearPhone) remove optional fields.
 end note
 
 EditCommand --> EditCommand : editedContact
@@ -70,8 +29,8 @@ EditCommand -> EditCommand : validate(editedContact)
 activate EditCommand
 
 note right of EditCommand
-  Check: contact must have
-  at least phone or email
+  Checks that the edited contact
+  retains at least a phone or email
 end note
 
 EditCommand --> EditCommand
@@ -83,28 +42,20 @@ activate Model
 Model --> EditCommand
 deactivate Model
 
-EditCommand -> Model : resetDisplayedContactList()
-activate Model
-
-Model --> EditCommand
-deactivate Model
-
 EditCommand -> Model : saveSnapshot(feedback)
 activate Model
 
 Model --> EditCommand
 deactivate Model
 
-create CommandResult
+create "r:CommandResult" as CommandResult LOGIC_COLOR
 EditCommand -> CommandResult
 activate CommandResult
 
 CommandResult --> EditCommand
 deactivate CommandResult
 
-EditCommand --> LogicManager : r
+EditCommand --> [: r
 deactivate EditCommand
 
-[<--LogicManager
-deactivate LogicManager
 @enduml


### PR DESCRIPTION
The edit command sequence diagram contained too much low-level parsing detail (LogicManager, AddressBookParser, EditCommandParser), making it difficult to interpret.

Simplified the diagram to focus on the EditCommand execution: createEditedContact, validate, and model interactions. Updated the DG description to match.

Fixes #361