### PR TITLE
fix: check duplicate UUIDs when loading data file

### DIFF
--- a/src/main/java/seedu/address/storage/JsonSerializableAddressBook.java
+++ b/src/main/java/seedu/address/storage/JsonSerializableAddressBook.java
@@ -1,7 +1,10 @@
 package seedu.address.storage;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -20,6 +23,7 @@ import seedu.address.model.contact.Contact;
 class JsonSerializableAddressBook {
 
     public static final String MESSAGE_DUPLICATE_CONTACT = "Contacts list contains duplicate contact(s).";
+    public static final String MESSAGE_DUPLICATE_CONTACT_IDS = "Contacts list contains duplicate contact ID(s).";
 
     private final List<JsonAdaptedContact> contacts = new ArrayList<>();
 
@@ -47,11 +51,16 @@ class JsonSerializableAddressBook {
      */
     public AddressBook toModelType() throws IllegalValueException {
         AddressBook addressBook = new AddressBook();
+        Set<UUID> contactIds = new HashSet<>();
         for (JsonAdaptedContact jsonAdaptedContact : contacts) {
             Contact contact = jsonAdaptedContact.toModelType();
             if (addressBook.hasContact(contact)) {
                 throw new IllegalValueException(MESSAGE_DUPLICATE_CONTACT);
             }
+            if (contactIds.contains(contact.getId())) {
+                throw new IllegalValueException(MESSAGE_DUPLICATE_CONTACT_IDS);
+            }
+            contactIds.add(contact.getId());
             addressBook.addContact(contact);
         }
         return addressBook;

--- a/src/test/data/JsonSerializableAddressBookTest/duplicateContactIdsAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/duplicateContactIdsAddressBook.json
@@ -1,0 +1,22 @@
+{
+  "contacts": [ {
+    "id" : "9510b03d-2787-420f-94c5-775093db5613",
+    "name": "Alice Pauline",
+    "phone": "94351253",
+    "email": "alice@example.com",
+    "address": "123, Jurong West Ave 6, #08-111",
+    "lastUpdated": "2026-02-22T09:00",
+    "tags": [ {
+      "type" : "JsonAdaptedTag",
+      "name" : "friends"
+    } ]
+  }, {
+    "id" : "9510b03d-2787-420f-94c5-775093db5613",
+    "name": "Alice Paul",
+    "phone": "94351253",
+    "email": "alice@example.com",
+    "lastUpdated": "2026-02-23T09:00",
+    "notes": [],
+    "address": "4th street"
+  } ]
+}

--- a/src/test/java/seedu/address/storage/JsonSerializableAddressBookTest.java
+++ b/src/test/java/seedu/address/storage/JsonSerializableAddressBookTest.java
@@ -19,6 +19,7 @@ public class JsonSerializableAddressBookTest {
     private static final Path TYPICAL_CONTACTS_FILE = TEST_DATA_FOLDER.resolve("typicalContactsAddressBook.json");
     private static final Path INVALID_CONTACT_FILE = TEST_DATA_FOLDER.resolve("invalidContactAddressBook.json");
     private static final Path DUPLICATE_CONTACT_FILE = TEST_DATA_FOLDER.resolve("duplicateContactAddressBook.json");
+    private static final Path DUPLICATE_CONTACT_IDS_FILE = TEST_DATA_FOLDER.resolve("duplicateContactIdsAddressBook.json");
 
     @Test
     public void toModelType_typicalContactsFile_success() throws Exception {
@@ -41,6 +42,14 @@ public class JsonSerializableAddressBookTest {
         JsonSerializableAddressBook dataFromFile = JsonUtil.readJsonFile(DUPLICATE_CONTACT_FILE,
                 JsonSerializableAddressBook.class).get();
         assertThrows(IllegalValueException.class, JsonSerializableAddressBook.MESSAGE_DUPLICATE_CONTACT,
+                dataFromFile::toModelType);
+    }
+
+    @Test
+    public void toModelType_duplicateContactIds_throwsIllegalValueException() throws Exception {
+        JsonSerializableAddressBook dataFromFile = JsonUtil.readJsonFile(DUPLICATE_CONTACT_IDS_FILE,
+                JsonSerializableAddressBook.class).get();
+        assertThrows(IllegalValueException.class, JsonSerializableAddressBook.MESSAGE_DUPLICATE_CONTACT_IDS,
                 dataFromFile::toModelType);
     }
 

--- a/src/test/java/seedu/address/storage/JsonSerializableAddressBookTest.java
+++ b/src/test/java/seedu/address/storage/JsonSerializableAddressBookTest.java
@@ -19,7 +19,8 @@ public class JsonSerializableAddressBookTest {
     private static final Path TYPICAL_CONTACTS_FILE = TEST_DATA_FOLDER.resolve("typicalContactsAddressBook.json");
     private static final Path INVALID_CONTACT_FILE = TEST_DATA_FOLDER.resolve("invalidContactAddressBook.json");
     private static final Path DUPLICATE_CONTACT_FILE = TEST_DATA_FOLDER.resolve("duplicateContactAddressBook.json");
-    private static final Path DUPLICATE_CONTACT_IDS_FILE = TEST_DATA_FOLDER.resolve("duplicateContactIdsAddressBook.json");
+    private static final Path DUPLICATE_CONTACT_IDS_FILE = TEST_DATA_FOLDER
+            .resolve("duplicateContactIdsAddressBook.json");
 
     @Test
     public void toModelType_typicalContactsFile_success() throws Exception {


### PR DESCRIPTION
While loading address book in `JsonSerializableAddressBook`, checks that there are no duplicate contact UUIDs.

Resolves #366.