### PR TITLE
fix: loosen name validation

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -230,7 +230,9 @@ If an incorrectly input date/time is indeed recorded, the user should use one of
 
 **Name(**`n/`**):**
 - The contact's name.
-- Can only contain alphanumeric characters and spaces.
+- Can contain symbols `.` `'` `-` `_` `&` `/` and letter characters from any language.
+- First character must be a letter character.
+- Must be non-empty.
 
 **Phone number(**`p/`**):**
 - The contact's phone number.
@@ -274,7 +276,6 @@ To add a new contact, use the [`add` command]({{ baseUrl }}/user-guide/add-conta
 Format: `add n/NAME (p/PHONE | e/EMAIL) [a/ADDRESS] [lc/LAST_CONTACTED] [t/TAG]…​`
 
 - At least **one** (or both) of `p/PHONE` or `e/EMAIL` must be provided.
-- Names are standardized to **Title Case**.
 - After adding, if similar contacts exist, the list will filter to show them.
 
 **Examples:**

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -2,11 +2,9 @@ package seedu.address.logic.parser;
 
 import static java.util.Objects.requireNonNull;
 
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.commons.util.StringUtil;
@@ -49,16 +47,10 @@ public class ParserUtil {
     public static Name parseName(String name) throws ParseException {
         requireNonNull(name);
         String trimmedName = name.trim();
-        if (trimmedName.isEmpty()) {
+        if (trimmedName.isEmpty() || !Name.isValidName(trimmedName)) {
             throw new ParseException(Name.MESSAGE_CONSTRAINTS);
         }
-        String[] splitName = trimmedName.split("\\s+");
-        String titledName = Arrays.stream(splitName)
-                .collect(Collectors.joining(" "));
-        if (!Name.isValidName(titledName)) {
-            throw new ParseException(Name.MESSAGE_CONSTRAINTS);
-        }
-        return new Name(titledName);
+        return new Name(trimmedName);
     }
 
     /**

--- a/src/main/java/seedu/address/model/contact/Name.java
+++ b/src/main/java/seedu/address/model/contact/Name.java
@@ -9,14 +9,14 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
  */
 public class Name implements Comparable<Name> {
 
-    public static final String MESSAGE_CONSTRAINTS =
-            "Names should only contain alphanumeric characters and spaces, and it should not be blank";
+    public static final String MESSAGE_CONSTRAINTS = "Names cannot be blank, and cannot start with a symbol.\n"
+            + "Permitted symbols are: . ' - _ & /";
 
     /*
      * The first character of the address must not be a whitespace,
      * otherwise " " (a blank string) becomes a valid input.
      */
-    public static final String VALIDATION_REGEX = "[\\p{Alnum}][\\p{Alnum} ]*";
+    public static final String VALIDATION_REGEX = "^[\\p{L}0-9][\\p{L}0-9 .'\\-_&\\/]*$";
 
     public final String fullName;
 
@@ -37,7 +37,6 @@ public class Name implements Comparable<Name> {
     public static boolean isValidName(String test) {
         return test.matches(VALIDATION_REGEX);
     }
-
 
     @Override
     public String toString() {

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -51,7 +51,7 @@ public class CommandTestUtil {
     public static final String TAG_DESC_FRIEND = " " + PREFIX_TAG + VALID_TAG_FRIEND;
     public static final String TAG_DESC_HUSBAND = " " + PREFIX_TAG + VALID_TAG_HUSBAND;
 
-    public static final String INVALID_NAME_DESC = " " + PREFIX_NAME + "James&"; // '&' not allowed in names
+    public static final String INVALID_NAME_DESC = " " + PREFIX_NAME + "James\\"; // '/' not allowed in names
     public static final String INVALID_PHONE_DESC = " " + PREFIX_PHONE + "911a"; // 'a' not allowed in phones
     public static final String INVALID_EMAIL_DESC = " " + PREFIX_EMAIL + "bob!yahoo"; // missing '@' symbol
     public static final String INVALID_ADDRESS_DESC = " " + PREFIX_ADDRESS; // empty string not allowed for addresses

--- a/src/test/java/seedu/address/model/contact/NameTest.java
+++ b/src/test/java/seedu/address/model/contact/NameTest.java
@@ -27,8 +27,9 @@ public class NameTest {
         // invalid name
         assertFalse(Name.isValidName("")); // empty string
         assertFalse(Name.isValidName(" ")); // spaces only
-        assertFalse(Name.isValidName("^")); // only non-alphanumeric characters
+        assertFalse(Name.isValidName("^")); // special symbol characters
         assertFalse(Name.isValidName("peter*")); // contains non-alphanumeric characters
+        assertFalse(Name.isValidName("-hello")); // starts with a symbol
 
         // valid name
         assertTrue(Name.isValidName("peter jack")); // alphabets only
@@ -36,6 +37,9 @@ public class NameTest {
         assertTrue(Name.isValidName("peter the 2nd")); // alphanumeric characters
         assertTrue(Name.isValidName("Capital Tan")); // with capital letters
         assertTrue(Name.isValidName("David Roger Jackson Ray Jr 2nd")); // long names
+        assertTrue(Name.isValidName("he-l/l o.")); // names with symbols
+        assertTrue(Name.isValidName("あきら")); // foreign names
+        assertTrue(Name.isValidName("小明")); // foreign names
     }
 
     @Test


### PR DESCRIPTION
Loosen name validation to the following regex, after trimming whitespace characters on both ends:
`^[\p{L}0-9][\p{L}0-9 .'\-_&\/]*$`

I.e. the following:
- Permitted symbols are `. ' - _ & /`
- First character cannot be a symbol
- Must have at least one character

Fixes #321.
Resolves #424.