### PR TITLE
fix: Fix textflow notes in contactDetailPanel bug

### DIFF
--- a/src/main/java/seedu/address/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/address/model/util/SampleDataUtil.java
@@ -38,7 +38,7 @@ public class SampleDataUtil {
                     Optional.of(new Address("Blk 30 Geylang Street 29, #06-40")),
                     Optional.of(new LastContacted(TimePointParser.toTimePoint("12 March 2026"))),
                     List.of(new Note("CEO: @{220e8400-e29b-41d4-a716-446655440000}"),
-                            new Note("Currently employing @{330e8400-e29b-41d4-a716-446655440000} and"
+                            new Note("Currently employing @{330e8400-e29b-41d4-a716-446655440000} and "
                                     + "@{550e8400-e29b-41d4-a716-446655440000}"),
                             new Note("Worked with @{440e8400-e29b-41d4-a716-446655440000} before")),
                     getTagSet("client")),

--- a/src/main/java/seedu/address/ui/ContactDetailPanel.java
+++ b/src/main/java/seedu/address/ui/ContactDetailPanel.java
@@ -119,6 +119,7 @@ public class ContactDetailPanel extends UiPart<Region> {
                         noteLabel.hideHeader();
                         Label indexLabel = new Label((notes.getChildren().size() + 1) + ". ");
                         indexLabel.getStyleClass().add("note-index-label");
+                        indexLabel.setMinWidth(Region.USE_PREF_SIZE);
                         HBox indexedNoteLabel = new HBox(indexLabel, noteLabel);
                         notes.getChildren().add(indexedNoteLabel); });
             UiUtil.show(notesContainer);

--- a/src/main/java/seedu/address/ui/NoteLabel.java
+++ b/src/main/java/seedu/address/ui/NoteLabel.java
@@ -24,6 +24,8 @@ public class NoteLabel extends HBox {
 
     private static final String FXML = "/view/NoteLabel.fxml";
 
+    private String style = "-fx-font-family: 'Segoe UI'; -fx-font-size: 13px; -fx-fill: white;";
+
     @FXML
     private Label reminderHeader;
     @FXML
@@ -34,9 +36,9 @@ public class NoteLabel extends HBox {
     private Label time;
 
     /**
-     * Creates a {@code NoteLabel} with contact reference resolution.
+     * Creates a {@code NoteLabel} with a set style and contact reference resolution.
      */
-    public NoteLabel(Note note, ObservableList<Contact> contacts) {
+    public NoteLabel(Note note, String style, ObservableList<Contact> contacts) {
         requireNonNull(note);
         FXMLLoader loader = new FXMLLoader(getClass().getResource(FXML));
 
@@ -52,7 +54,8 @@ public class NoteLabel extends HBox {
         if (note.hasContactReferences() && contacts != null) {
             // Replace the plain label with a TextFlow containing styled contact names
             int idx = getChildren().indexOf(text);
-            TextFlow textFlow = buildRichNoteText(note.value, contacts);
+            TextFlow textFlow = buildRichNoteText(note.value, style, contacts);
+            textFlow.getStyleClass().add(style);
             getChildren().set(idx, textFlow);
         } else {
             text.setText(note.value);
@@ -65,20 +68,7 @@ public class NoteLabel extends HBox {
             UiUtil.hide(reminderSeparator);
             UiUtil.hide(time);
         }
-    }
 
-    /**
-     * Creates a {@code NoteLabel} without contact reference resolution.
-     */
-    public NoteLabel(Note note) {
-        this(note, (ObservableList<Contact>) null);
-    }
-
-    /**
-     * Creates a {@code NoteLabel} with a set style and contact reference resolution.
-     */
-    public NoteLabel(Note note, String style, ObservableList<Contact> contacts) {
-        this(note, contacts);
         reminderHeader.getStyleClass().add(style);
         text.getStyleClass().add(style);
         reminderSeparator.getStyleClass().add(style);
@@ -86,17 +76,10 @@ public class NoteLabel extends HBox {
     }
 
     /**
-     * Creates a {@code NoteLabel} with a set style.
-     */
-    public NoteLabel(Note note, String style) {
-        this(note, style, null);
-    }
-
-    /**
      * Builds a {@code TextFlow} from note text, resolving {@code @{UUID}} references
      * to bold/underlined contact names.
      */
-    private TextFlow buildRichNoteText(String noteText, ObservableList<Contact> contacts) {
+    private TextFlow buildRichNoteText(String noteText, String style, ObservableList<Contact> contacts) {
         TextFlow textFlow = new TextFlow();
         Matcher matcher = Note.CONTACT_REF_PATTERN.matcher(noteText);
         int lastEnd = 0;
@@ -105,7 +88,7 @@ public class NoteLabel extends HBox {
             // Add plain text before this match
             if (matcher.start() > lastEnd) {
                 Text plainText = new Text(noteText.substring(lastEnd, matcher.start()));
-                plainText.setStyle("-fx-font-family: 'Segoe UI'; -fx-font-size: 13px; -fx-fill: white;");
+                plainText.getStyleClass().add(style);
                 textFlow.getChildren().add(plainText);
             }
 
@@ -120,7 +103,6 @@ public class NoteLabel extends HBox {
 
             Text refText = new Text(displayName);
             refText.getStyleClass().add("contact-reference");
-            refText.setStyle("-fx-font-size: 13px;");
             textFlow.getChildren().add(refText);
 
             lastEnd = matcher.end();
@@ -129,7 +111,7 @@ public class NoteLabel extends HBox {
         // Add remaining plain text
         if (lastEnd < noteText.length()) {
             Text plainText = new Text(noteText.substring(lastEnd));
-            plainText.setStyle("-fx-font-family: 'Segoe UI'; -fx-font-size: 13px; -fx-fill: white;");
+            plainText.setStyle(style);
             textFlow.getChildren().add(plainText);
         }
 

--- a/src/main/java/seedu/address/ui/NoteLabel.java
+++ b/src/main/java/seedu/address/ui/NoteLabel.java
@@ -24,8 +24,6 @@ public class NoteLabel extends HBox {
 
     private static final String FXML = "/view/NoteLabel.fxml";
 
-    private String style = "-fx-font-family: 'Segoe UI'; -fx-font-size: 13px; -fx-fill: white;";
-
     @FXML
     private Label reminderHeader;
     @FXML

--- a/src/main/java/seedu/address/ui/ReminderWindow.java
+++ b/src/main/java/seedu/address/ui/ReminderWindow.java
@@ -3,6 +3,7 @@ package seedu.address.ui;
 import java.util.List;
 import java.util.logging.Logger;
 
+import javafx.collections.FXCollections;
 import javafx.fxml.FXML;
 import javafx.scene.control.Label;
 import javafx.scene.layout.VBox;
@@ -53,7 +54,8 @@ public class ReminderWindow extends UiPart<Stage> {
             contact.getNotes().stream()
                     .filter(Note :: hasDueReminder)
                     .forEach(reminder -> {
-                        NoteLabel reminderLabel = new NoteLabel(reminder);
+                        NoteLabel reminderLabel =
+                                new NoteLabel(reminder, "label", FXCollections.observableList(contactList));
                         reminderLabel.hideHeader();
                         reminderMessageContainer.getChildren().add(reminderLabel); });
         });

--- a/src/main/resources/view/ContactDetailPanel.fxml
+++ b/src/main/resources/view/ContactDetailPanel.fxml
@@ -87,7 +87,7 @@
                 </padding>
                 <Label styleClass="detail-label" text="Notes:" />
                     <VBox>
-                        <VBox fx:id="notes" styleClass="detail-value"/>
+                        <VBox fx:id="notes" styleClass="detail-value" alignment="CENTER_LEFT"/>
                     </VBox>
             </VBox>
         </VBox>

--- a/src/main/resources/view/MainWindow.css
+++ b/src/main/resources/view/MainWindow.css
@@ -292,6 +292,24 @@
     -fx-font-family: "Segoe UI";
     -fx-font-size: 14px;
     -fx-text-fill: -main-font-color;
+    -fx-fill: -main-font-color;
+    -fx-padding: 3 0 0 0;
+}
+
+.contact-detail-panel .detail-value {
+    -fx-font-family: "Segoe UI";
+    -fx-font-size: 14px;
+    -fx-text-fill: -main-font-color;
+    -fx-fill: -main-font-color;
+    -fx-padding: 3 0 0 0;
+}
+
+.contact-detail-panel .contact-reference {
+    -fx-font-family: "Segoe UI";
+    -fx-font-size: 14px;
+    -fx-font-weight: bold;
+    -fx-underline: true;
+    -fx-fill: -contact-reference-fill;
     -fx-padding: 3 0 0 0;
 }
 

--- a/src/test/java/seedu/address/ui/NoteLabelTest.java
+++ b/src/test/java/seedu/address/ui/NoteLabelTest.java
@@ -25,38 +25,6 @@ import seedu.address.testutil.ContactBuilder;
 public class NoteLabelTest extends GuiUnitTest {
 
     @Test
-    public void constructor_plainNote_success() throws Exception {
-        runAndWait(() -> {
-            Note note = new Note("plain note text");
-            assertDoesNotThrow(() -> new NoteLabel(note));
-        });
-    }
-
-    @Test
-    public void constructor_noteWithStyle_success() throws Exception {
-        runAndWait(() -> {
-            Note note = new Note("styled note");
-            assertDoesNotThrow(() -> new NoteLabel(note, "detail-value"));
-        });
-    }
-
-    @Test
-    public void constructor_noteWithReminder_success() throws Exception {
-        runAndWait(() -> {
-            Note note = new Note("reminder note", TimePoint.of("2026-12-25"));
-            assertDoesNotThrow(() -> new NoteLabel(note));
-        });
-    }
-
-    @Test
-    public void constructor_noteWithReminderAndStyle_success() throws Exception {
-        runAndWait(() -> {
-            Note note = new Note("reminder note", TimePoint.of("2026-12-25"));
-            assertDoesNotThrow(() -> new NoteLabel(note, "detail-value"));
-        });
-    }
-
-    @Test
     public void constructor_noteWithContactRef_resolvesName() throws Exception {
         runAndWait(() -> {
             Contact alice = new ContactBuilder().withName("Alice Pauline").build();
@@ -64,7 +32,7 @@ public class NoteLabelTest extends GuiUnitTest {
             Note note = new Note("worked with @{" + aliceId + "}");
             ObservableList<Contact> contacts = FXCollections.observableArrayList(alice);
 
-            NoteLabel label = new NoteLabel(note, contacts);
+            NoteLabel label = new NoteLabel(note, "detail-value", contacts);
             assertNotNull(label);
 
             // Should contain a TextFlow instead of a plain label
@@ -103,7 +71,7 @@ public class NoteLabelTest extends GuiUnitTest {
             Note note = new Note("worked with @{" + unknownId + "}");
             ObservableList<Contact> contacts = FXCollections.observableArrayList();
 
-            NoteLabel label = new NoteLabel(note, contacts);
+            NoteLabel label = new NoteLabel(note, "detail-value", contacts);
             assertNotNull(label);
 
             // Should still contain a TextFlow with fallback text
@@ -126,7 +94,7 @@ public class NoteLabelTest extends GuiUnitTest {
             Note note = new Note("met @{" + bobId + "} at conference");
             ObservableList<Contact> contacts = FXCollections.observableArrayList(bob);
 
-            NoteLabel label = new NoteLabel(note, contacts);
+            NoteLabel label = new NoteLabel(note, "detail-value", contacts);
             TextFlow textFlow = (TextFlow) label.getChildren().stream()
                     .filter(node -> node instanceof TextFlow)
                     .findFirst().get();
@@ -153,7 +121,7 @@ public class NoteLabelTest extends GuiUnitTest {
             Note note = new Note("worked with @{" + someId + "}");
 
             // null contacts should not create TextFlow
-            NoteLabel label = new NoteLabel(note, (ObservableList<Contact>) null);
+            NoteLabel label = new NoteLabel(note, "detail-value", (ObservableList<Contact>) null);
             boolean hasTextFlow = label.getChildren().stream()
                     .anyMatch(node -> node instanceof TextFlow);
             assertFalse(hasTextFlow);
@@ -170,7 +138,7 @@ public class NoteLabelTest extends GuiUnitTest {
             Note note = new Note("@{" + aliceId + "} and @{" + bobId + "}");
             ObservableList<Contact> contacts = FXCollections.observableArrayList(alice, bob);
 
-            NoteLabel label = new NoteLabel(note, contacts);
+            NoteLabel label = new NoteLabel(note, "detail-value", contacts);
             TextFlow textFlow = (TextFlow) label.getChildren().stream()
                     .filter(node -> node instanceof TextFlow)
                     .findFirst().get();
@@ -183,8 +151,9 @@ public class NoteLabelTest extends GuiUnitTest {
     @Test
     public void hideHeader_hidesReminderHeader() throws Exception {
         runAndWait(() -> {
+            ObservableList<Contact> contacts = FXCollections.observableArrayList();
             Note note = new Note("test note", TimePoint.of("2026-12-25"));
-            NoteLabel label = new NoteLabel(note);
+            NoteLabel label = new NoteLabel(note, "detail-value", contacts);
             assertDoesNotThrow(() -> label.hideHeader());
         });
     }
@@ -197,7 +166,7 @@ public class NoteLabelTest extends GuiUnitTest {
             Note note = new Note("@{" + aliceId + "} is great");
             ObservableList<Contact> contacts = FXCollections.observableArrayList(alice);
 
-            NoteLabel label = new NoteLabel(note, contacts);
+            NoteLabel label = new NoteLabel(note, "detail-value", contacts);
             TextFlow textFlow = (TextFlow) label.getChildren().stream()
                     .filter(node -> node instanceof TextFlow)
                     .findFirst().get();
@@ -216,7 +185,7 @@ public class NoteLabelTest extends GuiUnitTest {
             Note note = new Note("works with @{" + aliceId + "}");
             ObservableList<Contact> contacts = FXCollections.observableArrayList(alice);
 
-            NoteLabel label = new NoteLabel(note, contacts);
+            NoteLabel label = new NoteLabel(note, "detail-value", contacts);
             TextFlow textFlow = (TextFlow) label.getChildren().stream()
                     .filter(node -> node instanceof TextFlow)
                     .findFirst().get();


### PR DESCRIPTION
- Textflow notes would not render properly in ContactListPanel
- If a note is too long, it would take space over the index

Both of these has been fixed by this PR

Before:
<img width="1008" height="1011" alt="image" src="https://github.com/user-attachments/assets/7ca2a2a7-eaf2-4cbe-a7ff-3404c31d7de5" />


After:
<img width="1013" height="1013" alt="image" src="https://github.com/user-attachments/assets/1b3dce4a-30f5-4cb1-82e0-9320d5c7a420" />
